### PR TITLE
Release 1.2.2: Git Flow branch strategy

### DIFF
--- a/.claude/skills/branch-management/SKILL.md
+++ b/.claude/skills/branch-management/SKILL.md
@@ -13,66 +13,26 @@ allowed-tools: [Bash, Read, Grep, Glob]
 - リリースフロー全体（version bump → tag → merge）は `/release-procedure` skill を参照
 - CI 実行方法・エラー対処は `/local-ci` skill を参照
 
-## トリガー条件
-
-以下の操作について議論・作業する際に自動的に実行:
-
-- `main` ブランチへのマージ・PR作成
-- `develop` ブランチへのマージ・PR作成
-- `release/*` ブランチの作成・マージ
-- 作業ブランチの作成・派生元の決定
-
 ## ブランチ戦略
 
-### 全体フロー図
+### ブランチの役割
 
-```mermaid
-flowchart LR
-    subgraph Protected["保護ブランチ（直接push禁止）"]
-        main[main]
-        develop[develop]
-    end
+| ブランチ | 役割 | 派生元 |
+|---------|------|--------|
+| `main` | 本番リリース（tag 付与対象） | - |
+| `develop` | 開発統合ブランチ | - |
+| `release/*` | リリース準備 | develop |
+| `feature/*` | 新機能 | develop |
+| `fix/*` | バグ修正 | develop |
+| `refactor/*` | リファクタリング | develop |
+| `docs/*` | ドキュメント | develop |
 
-    subgraph Release["リリースブランチ"]
-        release[release/*]
-    end
+### フロー
 
-    subgraph Work["作業ブランチ"]
-        feature[feature/*]
-        fix[fix/*]
-        refactor[refactor/*]
-        docs[docs/*]
-    end
-
-    develop -->|派生| release
-    release -->|派生| feature
-    release -->|派生| fix
-    release -->|派生| refactor
-    release -->|派生| docs
-
-    feature -->|PR| release
-    fix -->|PR| release
-    refactor -->|PR| release
-    docs -->|PR| release
-
-    release -->|PR| develop
-    develop -->|PR| main
 ```
-
-### マージ方向図
-
-```mermaid
-flowchart TD
-    A[作業ブランチ] -->|"① PR作成・マージ"| B[release/*]
-    B -->|"② PR作成・マージ"| C[develop]
-    C -->|"③ PR作成・マージ"| D[main]
-    D -->|"④ vタグ付与"| E[リリース完了]
-
-    style A fill:#e1f5fe
-    style B fill:#fff3e0
-    style C fill:#f3e5f5
-    style D fill:#e8f5e9
-    style E fill:#fce4ec
+feature/* ─┐
+fix/*      ├─→ develop → release/* → develop → main → tag
+refactor/* ─┘
 ```
 
 ## ルール一覧
@@ -80,114 +40,35 @@ flowchart TD
 | 操作 | 許可 | 禁止 |
 |------|------|------|
 | main への変更 | develop からの PR マージのみ | 直接 push、他ブランチからのマージ |
-| develop への変更 | release/* からの PR マージのみ | 直接 push |
+| develop への変更 | 作業ブランチ or release/* からの PR マージ | 直接 push |
 | release/* の作成 | develop から派生 | main や作業ブランチから派生 |
-| 作業ブランチの作成 | release/* から派生 | main や develop から直接派生 |
+| 作業ブランチの作成 | develop から派生 | main から直接派生 |
 
 ## 実施手順
 
-### 1. 現在のブランチ状態を確認
-
-```bash
-git branch -a
-git log --oneline -5
-```
-
-### 2. 操作タイプ別の確認
-
-#### 作業ブランチを作成する場合
-
-```bash
-# 正しい手順
-git checkout release/x.y.z
-git checkout -b feature/my-feature
-
-# または
-git checkout -b feature/my-feature release/x.y.z
-```
-
-#### PR を作成する場合
-
-| 現在のブランチ | PR先 | コマンド例 |
-|---------------|------|-----------|
-| feature/*, fix/*, refactor/*, docs/* | release/* | `gh pr create --base release/x.y.z` |
-| release/* | develop | `gh pr create --base develop` |
-| develop | main | `gh pr create --base main` |
-
-#### PR をマージする場合
-
-##### 1. PR の状態確認
-
-```bash
-# PR一覧を確認
-gh pr list
-
-# 特定のPRの詳細を確認
-gh pr view <PR番号>
-
-# CIステータスを確認
-gh pr checks <PR番号>
-```
-
-##### 2. マージ前チェックリスト
-
-```mermaid
-flowchart TD
-    A[PRマージ開始] --> B{CIが通過?}
-    B -->|No| C[CI失敗を修正]
-    C --> B
-    B -->|Yes| D{レビュー承認済み?}
-    D -->|No| E[レビューを依頼]
-    E --> D
-    D -->|Yes| F{コンフリクトなし?}
-    F -->|No| G[コンフリクト解消]
-    G --> F
-    F -->|Yes| H[マージ実行]
-    H --> I[ローカル反映]
-```
-
-##### 3. マージ実行
-
-```bash
-# Squash マージ（推奨：コミット履歴をクリーンに保つ）
-gh pr merge <PR番号> --squash
-
-# 通常マージ（コミット履歴を保持）
-gh pr merge <PR番号> --merge
-
-# リベースマージ
-gh pr merge <PR番号> --rebase
-```
-
-##### 4. マージ方法の選択基準
-
-| マージ方法 | 使用場面 | コマンド |
-|-----------|---------|---------|
-| Squash | 作業ブランチ → release（複数コミットを1つに） | `gh pr merge --squash` |
-| Merge | release → develop（履歴保持） | `gh pr merge --merge` |
-| Merge | develop → main（履歴保持） | `gh pr merge --merge` |
-
-##### 5. マージ後の確認
-
-```bash
-# マージ完了を確認
-gh pr view <PR番号> --json state
-
-# リモートの状態を確認
-git fetch origin
-git log origin/develop --oneline -5
-```
-
-#### マージ後のローカル反映
+### 作業ブランチを作成する場合
 
 ```bash
 git checkout develop
 git pull origin develop
+git checkout -b feature/my-feature
 ```
 
-### 3. リリースフロー
+### PR を作成する場合
 
-リリース手順（version bump → PR → merge → vtag）の詳細は `/release-procedure` skill を参照。
+| 現在のブランチ | PR先 | コマンド例 |
+|---------------|------|-----------|
+| feature/*, fix/*, refactor/*, docs/* | develop | `gh pr create --base develop` |
+| release/* | develop | `gh pr create --base develop` |
+| develop | main | `gh pr create --base main` |
+
+### マージ方法の選択基準
+
+| マージ方法 | 使用場面 | コマンド |
+|-----------|---------|---------|
+| Squash | 作業ブランチ → develop（複数コミットを1つに） | `gh pr merge --squash` |
+| Merge | release → develop（履歴保持） | `gh pr merge --merge` |
+| Merge | develop → main（履歴保持） | `gh pr merge --merge` |
 
 ## 警告パターン
 
@@ -196,35 +77,24 @@ git pull origin develop
 | 操作 | 警告メッセージ |
 |------|---------------|
 | `git push origin main` | main への直接 push は禁止です。develop からの PR を作成してください。 |
-| `git push origin develop` | develop への直接 push は禁止です。release/* からの PR を作成してください。 |
-| `git checkout -b feature/* develop` | 作業ブランチは release/* から派生してください。 |
-| `git checkout -b refactor/* develop` | 作業ブランチは release/* から派生してください。 |
+| `git push origin develop` | develop への直接 push は禁止です。作業ブランチからの PR を作成してください。 |
+| `git checkout -b feature/* main` | 作業ブランチは develop から派生してください。 |
 | `git merge main` | main からのマージは想定外です。派生元を確認してください。 |
 
 ## クイックリファレンス
 
 ```
-作業ブランチの種類:
-  feature/*  - 新機能
-  fix/*      - バグ修正
-  refactor/* - リファクタリング
-  docs/*     - ドキュメント
-
 作業開始:
-  git checkout release/x.y.z
-  git checkout -b feature/my-work   # または refactor/*, fix/*, docs/*
+  git checkout develop && git pull origin develop
+  git checkout -b feature/my-work
 
 作業完了（PR作成）:
-  gh pr create --base release/x.y.z
+  gh pr create --base develop
 
 PRマージ:
-  gh pr checks <PR番号>           # CI確認
+  gh pr checks <PR番号>
   gh pr merge <PR番号> --squash   # 作業ブランチ用
   gh pr merge <PR番号> --merge    # release/develop用
-
-マージ後のローカル反映:
-  git checkout <マージ先ブランチ>
-  git pull origin <マージ先ブランチ>
 
 完全リリースフロー:
   /release-procedure skill を参照

--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -13,4 +13,9 @@ scripts/bump_version.sh
 - Updates `deno.json` only and commits the change
 - Does NOT create a git tag (use `scripts/create_release_tag.sh` on main for that)
 
+## バージョンレベルの判断
+
+- **デフォルトは patch**（例: 1.2.1 → 1.2.2）
+- minor バージョンアップ（例: 1.2.2 → 1.3.0）はユーザーが明示的に指示した場合のみ
+
 Only run when explicitly ordered. Do not speculate about releases.

--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -9,4 +9,8 @@ Run the version bump script:
 scripts/bump_version.sh
 ```
 
+- Detects version from `release/*` branch name, or accepts an explicit argument: `scripts/bump_version.sh 1.3.0`
+- Updates `deno.json` only and commits the change
+- Does NOT create a git tag (use `scripts/create_release_tag.sh` on main for that)
+
 Only run when explicitly ordered. Do not speculate about releases.

--- a/.claude/skills/release-procedure/SKILL.md
+++ b/.claude/skills/release-procedure/SKILL.md
@@ -8,87 +8,108 @@ allowed-tools: [Bash, Read, Edit, Grep, Glob]
 
 ## 責務
 
-リリースフロー全体を管理する（version bump → tag → PR → merge の手順）。
+リリースフロー全体を管理する（version bump → PR → merge → tag の手順）。
 
 - ブランチ戦略・命名規則の詳細は `/branch-management` skill を参照
 - CI 実行方法・エラー対処の詳細は `/local-ci` skill を参照
 
-## リリースブランチ作成時のチェックリスト
+## バージョン管理ファイル
 
-**release/* ブランチを作成したら、必ず以下を実行:**
+このプロジェクトでは `deno.json` の `version` フィールドのみでバージョンを管理する。
+
+## リリースフロー
+
+### フロー図
+
+```
+develop → release/x.y.z → (bump & CI) → PR: release → develop → PR: develop → main → tag → JSR publish
+```
+
+### 手順詳細
+
+#### ステップ 1: release/* ブランチ作成
 
 ```bash
-# 1. バージョン自動更新（ブランチ名から検出）
-deno task bump-version
+git checkout develop
+git pull origin develop
+git checkout -b release/x.y.z
+```
 
-# 2. 確認
+#### ステップ 2: バージョンアップ
+
+```bash
+# ブランチ名から自動検出してバージョン更新
+scripts/bump_version.sh
+
+# または明示的に指定
+scripts/bump_version.sh x.y.z
+
+# 確認
 grep '"version"' deno.json
-grep 'CLIMPT_VERSION' src/version.ts
+```
 
-# 3. ローカルCI
-deno task ci
+#### ステップ 3: ローカルCI確認
 
-# 4. コミット & プッシュ
-git add deno.json src/version.ts
-git commit -m "chore: bump version to x.y.z"
+```bash
+scripts/local_ci.sh
+```
+
+#### ステップ 4: プッシュ
+
+```bash
 git push -u origin release/x.y.z
 ```
 
-## ドキュメント更新（リリース前必須）
-
-**重要**: リリース前に以下の2つのスキルを使用してドキュメントを更新すること。
-
-### 1. CHANGELOG 更新
-
-`/update-changelog` スキルを使用:
-- 変更内容を [Unreleased] セクションに記載
-- 検索可能なキーワードを含める（コマンド名、オプション名、設定名）
-- リリース時に [x.y.z] - YYYY-MM-DD へ移動
-
-### 2. ドキュメント更新
-
-`/update-docs` スキルを使用:
-- 変更の種類に応じて適切な場所を更新
-- CLI オプション変更 → `--help` 必須、README 推奨
-- 新機能 → README に簡潔な説明とサンプル
-- 設定変更 → スキーマ説明、README/docs
-
-### 3. docs/manifest.json 更新
-
-リリース前に `docs/manifest.json` を最新状態に更新する:
-
-- `version` フィールドをリリースバージョンに更新
-- エントリの追加・削除: `docs/` 配下のファイル増減を反映
-- `bytes` フィールド: 各ファイルの実サイズと一致させる
-- `lang` フィールド: en/ja ガイドには必ず指定
+#### ステップ 5: release/* → develop PR
 
 ```bash
-# 確認: manifest のエントリと実ファイルの突き合わせ
-ls docs/*.md docs/guides/en/*.md docs/guides/ja/*.md
-# manifest に無いファイル、または manifest にあるが存在しないファイルがないか確認
+gh pr create --base develop --head release/x.y.z \
+  --title "Release x.y.z: <変更概要>" \
+  --body "## Summary
+- <変更点>
 
-# bytes 確認
-wc -c docs/*.md docs/guides/en/*.md docs/guides/ja/*.md
+## Version
+- x.y.z"
 ```
 
-### チェックリスト
+#### ステップ 6: CI確認 & develop へマージ
 
-```
-□ CHANGELOG.md に変更を記載（/update-changelog）
-□ 必要なドキュメントを更新（/update-docs）
-  □ CLI変更 → --help 出力確認
-  □ 新機能 → README.md / README.ja.md
-  □ Agent変更 → agents/README.md
-  □ 設定変更 → スキーマ説明
-□ docs/manifest.json を更新
-  □ version をリリースバージョンに更新
-  □ ファイル追加・削除を反映
-  □ bytes を実サイズに更新
-□ examples/ E2E 検証を実行（CI通過後、PR作成前）
+```bash
+gh pr checks <PR番号> --watch
+gh pr merge <PR番号> --merge
 ```
 
-**重要**: `deno task bump-version` は release/* ブランチ名からバージョンを自動検出する。
-手動指定も可能: `deno task bump-version 1.10.2`
+#### ステップ 7: develop → main PR
+
+```bash
+gh pr create --base main --head develop \
+  --title "Release x.y.z" \
+  --body "Release version x.y.z to production"
+```
+
+#### ステップ 8: CI確認 & main へマージ
+
+```bash
+gh pr checks <PR番号> --watch
+gh pr merge <PR番号> --merge
+```
+
+#### ステップ 9: tag 作成（JSR publish トリガー）
+
+```bash
+git checkout main
+git pull origin main
+scripts/create_release_tag.sh
+```
+
+tag push が `publish.yml` をトリガーして JSR publish が自動実行される。
+
+#### ステップ 10: クリーンアップ
+
+```bash
+git branch -d release/x.y.z
+git push origin --delete release/x.y.z
+```
 
 ## 重要: 連続マージの禁止事項
 
@@ -102,302 +123,26 @@ wc -c docs/*.md docs/guides/en/*.md docs/guides/ja/*.md
 正しい手順:
 1. 各 PR 作成後、ユーザーに報告して次の指示を待つ
 2. 「develop まで」「main まで」等の明示的な指示を確認
-3. vtag 作成もユーザーの指示を待つ
-
-## トリガー条件
-
-以下の操作について議論・作業する際に自動的に実行:
-
-- `release/*` ブランチへの push
-- `release/*` → `develop` への PR 作成・マージ
-- `develop` → `main` への PR 作成・マージ
-- バージョンアップ・リリースに関する議論
-- vtag の作成
-
-## バージョン管理ファイル
-
-このプロジェクトでは以下の2ファイルでバージョンを管理:
-
-| ファイル | 用途 |
-|---------|------|
-| `deno.json` | JSR パッケージバージョン（`"version": "x.y.z"`） |
-| `src/version.ts` | CLI バージョン定数（`CLIMPT_VERSION = "x.y.z"`） |
-
-**重要**: 両ファイルのバージョンは必ず一致させること。CIで自動チェックされる。
-
-## バージョンアップ手順
-
-### 1. バージョン番号の決定
-
-```
-パッチ (x.y.Z): バグ修正、ドキュメント改善
-マイナー (x.Y.0): 新機能追加（後方互換あり）
-メジャー (X.0.0): 破壊的変更
-```
-
-### 2. ファイル更新
-
-```bash
-# deno.json
-# "version": "1.9.13" → "version": "1.9.14"
-
-# src/version.ts
-# export const CLIMPT_VERSION = "1.9.13"; → "1.9.14";
-```
-
-### 3. 確認コマンド
-
-```bash
-# バージョン一致確認
-grep '"version"' deno.json | head -1
-grep 'CLIMPT_VERSION' src/version.ts | grep export
-```
-
-## リリースフロー
-
-### フロー図
-
-```mermaid
-sequenceDiagram
-    participant R as release/x.y.z
-    participant D as develop
-    participant M as main
-    participant T as vtag
-
-    Note over R: 1. バージョンアップ
-    R->>R: deno.json, version.ts 更新
-    Note over R: 2. ローカルCI確認
-    R->>R: deno task ci
-    R->>R: 3. git commit & push
-
-    R->>D: 4. PR作成 (release → develop)
-    Note over D: 5. CI確認（全てpass）
-    D->>D: PRマージ
-
-    D->>M: 6. PR作成 (develop → main)
-    Note over M: 7. CI確認（全てpass）
-    M->>M: PRマージ
-    Note over M: JSR publish 自動実行
-
-    M->>T: 8. vtag作成
-    Note over T: git tag vx.y.z
-```
-
-### 手順詳細
-
-#### ステップ 0: 準備
-
-```bash
-# 作業ブランチを release/* に統合済みか確認
-git checkout release/x.y.z
-git log --oneline -10
-```
-
-#### ステップ 1: release/* ブランチでバージョンアップ
-
-```bash
-# develop から新規作成する場合
-git checkout develop
-git checkout -b release/x.y.z
-
-# または既存 release/* で作業
-git checkout release/x.y.z
-```
-
-バージョン更新（自動スクリプト使用）:
-
-```bash
-# ブランチ名から自動検出してバージョン更新
-deno task bump-version
-
-# または明示的に指定
-deno task bump-version x.y.z
-
-# 確認
-grep '"version"' deno.json
-grep 'export const CLIMPT_VERSION' src/version.ts
-```
-
-#### ステップ 2: ローカルCI確認
-
-**重要**: プッシュ前に必ずローカルでCIを通すこと。実行方法の詳細は `/local-ci` skill を参照。
-
-```bash
-deno task ci
-```
-
-#### ステップ 2.5: Examples E2E 検証
-
-**重要**: CI通過後、PR作成前に `examples/` スクリプトで E2E 検証を行うこと。
-
-```bash
-chmod +x examples/**/*.sh examples/*.sh
-./examples/01_setup/01_install.sh
-./examples/02_cli_basic/01_echo_test.sh
-# ... 各カテゴリを実行
-./examples/07_clean.sh
-```
-
-対象: `01_setup` ～ `06_registry` の各カテゴリ。詳細は [`examples/README.md`](../../examples/README.md) を参照。
-
-#### ステップ 3: コミット & プッシュ
-
-```bash
-git add deno.json src/version.ts
-git commit -m "chore: bump version to x.y.z"
-git push -u origin release/x.y.z
-```
-
-**注意**: サンドボックス制限については `/git-gh-sandbox` skill を参照
-
-#### ステップ 4: release/* → develop PR
-
-```bash
-gh pr create --base develop --head release/x.y.z \
-  --title "Release x.y.z: <変更概要>" \
-  --body "## Summary
-- <変更点>
-
-## Version
-- x.y.z"
-```
-
-#### ステップ 5: CI確認 & develop へマージ
-
-**重要**: マージ前にPRのCIが全てパスすることを確認
-
-```bash
-# CI確認（全てpassになるまで待機）
-gh pr checks <PR番号> --watch
-
-# CIがpassしたらマージ
-gh pr merge <PR番号> --merge
-```
-
-#### ステップ 6: develop → main PR
-
-```bash
-gh pr create --base main --head develop \
-  --title "Release x.y.z" \
-  --body "Release version x.y.z to production"
-```
-
-#### ステップ 7: CI確認 & main へマージ
-
-**重要**: マージ前にPRのCIが全てパスすることを確認
-
-```bash
-# CI確認（全てpassになるまで待機）
-gh pr checks <PR番号> --watch
-
-# CIがpassしたらマージ
-gh pr merge <PR番号> --merge
-```
-
-**自動処理**: main マージ時に JSR publish が自動実行される
-
-#### ステップ 8: vtag 作成
-
-```bash
-# main の最新コミットを取得
-git fetch origin main
-
-# vtag 作成 & push
-git tag vx.y.z origin/main
-git push origin vx.y.z
-```
-
-**重要**: vtag は必ず main ブランチのコミットに付与する
-
-#### ステップ 9: クリーンアップ（ブランチ削除）
-
-マージ後のブランチ削除を行う。削除判断基準・手順の詳細は `/branch-management` skill を参照。
-
-```bash
-# release ブランチ削除例
-git branch -D release/x.y.z
-git push origin --delete release/x.y.z
-```
-
-## CI バージョンチェック
-
-`.github/workflows/test.yml` で以下を自動チェック:
-
-### チェック内容
-
-| チェック項目 | 対象ブランチ | 失敗時のエラー |
-|-------------|-------------|---------------|
-| deno.json と version.ts の一致 | 全ブランチ | `Version mismatch: deno.json=X, version.ts=Y` |
-| ブランチ名とバージョンの一致 | release/* のみ | `Branch version mismatch: branch=X, deno.json=Y` |
-
-### release/* ブランチでの追加チェック
-
-```
-release/1.9.15 ブランチでは:
-- deno.json の version が "1.9.15" であること
-- src/version.ts の CLIMPT_VERSION が "1.9.15" であること
-```
-
-### チェックを通すための確認コマンド
-
-```bash
-# 現在のブランチ名からバージョンを確認
-git branch --show-current | sed 's|release/||'
-
-# deno.json のバージョン
-grep '"version"' deno.json | head -1 | sed 's/.*"\([0-9.]*\)".*/\1/'
-
-# version.ts のバージョン
-grep 'export const CLIMPT_VERSION' src/version.ts | sed 's/.*"\([0-9.]*\)".*/\1/'
-
-# 3つが全て一致することを確認
-```
-
-### チェック失敗時の対処
-
-```bash
-# release/1.9.15 でバージョンが 1.9.14 のままだった場合
-# 1. deno.json を編集: "version": "1.9.15"
-# 2. version.ts を編集: CLIMPT_VERSION = "1.9.15"
-# 3. コミット & push
-git add deno.json src/version.ts
-git commit -m "fix: correct version to 1.9.15"
-git push origin release/1.9.15
-```
+3. tag 作成もユーザーの指示を待つ
 
 ## クイックリファレンス
 
 ```
 バージョンアップ:
-  1. deno.json の version を更新
-  2. src/version.ts の CLIMPT_VERSION を更新
-  3. deno task ci  ← ローカルCIを通す（重要）
-  4. git commit -m "chore: bump version to x.y.z"
-
-ドキュメント更新（リリース前必須）:
-  1. /update-changelog → CHANGELOG.md に変更を記載
-  2. /update-docs → README, --help 等を必要に応じて更新
-  3. docs/manifest.json → version, entries, bytes を最新化
-
-E2E 検証（CI通過後、PR作成前）:
-  chmod +x examples/**/*.sh examples/*.sh
-  ./examples/01_setup/01_install.sh ～ ./examples/06_registry/
-  ./examples/07_clean.sh
+  1. develop から release/x.y.z 作成
+  2. scripts/bump_version.sh 実行
+  3. scripts/local_ci.sh 実行
+  4. git push -u origin release/x.y.z
 
 リリースフロー:
-  1. release/* → develop PR作成
-  2. gh pr checks <PR番号> --watch  ← CIがpassするまで待機
-  3. gh pr merge <PR番号> --merge
-  4. develop → main PR作成
-  5. gh pr checks <PR番号> --watch  ← CIがpassするまで待機
-  6. gh pr merge <PR番号> --merge (JSR publish 自動)
-  7. vtag作成: git tag vx.y.z origin/main && git push origin vx.y.z
-  8. クリーンアップ: ブランチ削除（/branch-management 参照）
+  1. PR: release/x.y.z → develop 作成 & マージ
+  2. PR: develop → main 作成 & マージ
+  3. main で scripts/create_release_tag.sh → JSR publish 自動
+  4. release/* ブランチ削除
 
 関連Skill:
   - CI実行・エラー対処 → /local-ci, /ci-troubleshooting
   - ブランチ戦略・削除判断 → /branch-management
-  - サンドボックス制限 → /git-gh-sandbox
 ```
 
 ## トラブルシューティング
@@ -407,34 +152,26 @@ E2E 検証（CI通過後、PR作成前）:
 原因: deno.json のバージョンが既存と同じ
 
 ```bash
-# 確認
 gh run view <run-id> --log | grep -i "skip"
-
-# 対処: バージョンを上げて再リリース
 ```
 
 ### CI バージョンチェック失敗
 
-原因: deno.json と version.ts の不一致、またはブランチ名との不一致
+原因: deno.json とブランチ名の不一致
 
 ```bash
-# 確認
 grep '"version"' deno.json
-grep 'export const CLIMPT_VERSION' src/version.ts
 git branch --show-current
-
-# 対処: 全て同じバージョンに統一
+# 対処: scripts/bump_version.sh を再実行
 ```
 
-### vtag が古いコミットを指している
+### tag が古いコミットを指している
 
 ```bash
-# 確認
 git show vx.y.z --oneline
 
 # 対処: タグ削除 & 再作成
 git tag -d vx.y.z
 git push origin :refs/tags/vx.y.z
-git tag vx.y.z origin/main
-git push origin vx.y.z
+scripts/create_release_tag.sh
 ```

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, "release/*"]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   lint-and-format:

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -2,9 +2,9 @@ name: Version Check
 
 on:
   push:
-    branches: [main]
+    branches: [main, "release/*"]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   version-check:
@@ -16,9 +16,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.1.9
+          deno-version: v2.x
 
       - name: Clear cache and regenerate lockfile
         run: |
@@ -40,10 +40,35 @@ jobs:
       - name: Get latest JSR version
         id: get_jsr_version
         run: |
-          JSR_VERSION=$(curl -s https://jsr.io/@tettuan/breakdownprompt/versions | grep -o '0\.[0-9]\+\.[0-9]\+' | head -n 1 || echo "0.0.0")
+          JSR_VERSION=$(curl -s https://jsr.io/@tettuan/breakdownconfig/meta.json | jq -r '.latestVersion // "0.0.0"')
           echo "jsr_version=${JSR_VERSION}" >> $GITHUB_OUTPUT
 
-      - name: Check version consistency
+      - name: Detect branch context
+        id: branch_context
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            BRANCH="${GITHUB_REF#refs/heads/}"
+          else
+            BRANCH="${{ github.head_ref }}"
+          fi
+          echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
+
+          if [[ "$BRANCH" == release/* ]]; then
+            echo "is_release=true" >> $GITHUB_OUTPUT
+            echo "release_version=${BRANCH#release/}" >> $GITHUB_OUTPUT
+          else
+            echo "is_release=false" >> $GITHUB_OUTPUT
+            echo "release_version=" >> $GITHUB_OUTPUT
+          fi
+
+          if [ "$BRANCH" = "main" ]; then
+            echo "is_main=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_main=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check version consistency (main only)
+        if: steps.branch_context.outputs.is_main == 'true'
         run: |
           if [ "v${{ steps.get_version.outputs.version }}" != "${{ steps.get_latest_tag.outputs.latest_tag }}" ]; then
             echo "Error: Version mismatch!"
@@ -60,3 +85,19 @@ jobs:
           fi
 
           echo "Version check passed! New version: ${{ steps.get_version.outputs.version }}"
+
+      - name: Check release branch version consistency
+        if: steps.branch_context.outputs.is_release == 'true'
+        run: |
+          BRANCH_VERSION="${{ steps.branch_context.outputs.release_version }}"
+          DENO_VERSION="${{ steps.get_version.outputs.version }}"
+
+          if [ "$BRANCH_VERSION" != "$DENO_VERSION" ]; then
+            echo "Error: Branch version mismatch!"
+            echo "Branch name version: $BRANCH_VERSION"
+            echo "deno.json version:   $DENO_VERSION"
+            echo "Run: scripts/bump_version.sh"
+            exit 1
+          fi
+
+          echo "Release branch version check passed: $DENO_VERSION"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ alwaysApply: false
 
 - Project: Deno, JSR publish
 - use `LOG_LEVEL=debug deno test --allow-env --allow-write --allow-read` to debug, or other log level.
-- publish JSR with CI. see `https://jsr.io/@tettuan/breakdownprompt/publish`
+- publish JSR with CI. see `https://jsr.io/@tettuan/breakdownconfig/publish`
 - run `deno test <something.ts> --allow-env --allow-write --allow-read` before git commit.
 - run `scripts/local_ci.sh` before merge or push.
 - tests and fixtures must be in `tests/`.
@@ -24,8 +24,10 @@ alwaysApply: false
 
 # Git push
 
-- DO NOT push untile `scripts/local_ci.sh` pass all.
+- DO NOT push until `scripts/local_ci.sh` pass all.
 - run `LOG_LEVEL=debug scripts/local_ci.sh` if error.
+- NEVER push directly to `main` or `develop`. Always use PR.
+- Work on `feature/*`, `fix/*`, `refactor/*`, or `docs/*` branches (derived from `develop`).
 
 # Run Tests
 
@@ -69,10 +71,35 @@ alwaysApply: false
 
 - Write Comments when only test passes.
 
+# Branch Strategy
+
+全ての変更は以下のブランチ戦略に従って行うこと。直接 main/develop への push は禁止。
+
+## ブランチの役割
+
+| ブランチ | 役割 | 直接 push |
+|---------|------|----------|
+| `main` | 本番リリース。tag 付与対象 | 禁止 |
+| `develop` | 開発統合ブランチ | 禁止 |
+| `release/*` | リリース準備。develop から派生 | 可 |
+| `feature/*`, `fix/*`, `refactor/*`, `docs/*` | 作業ブランチ。develop から派生 | 可 |
+
+## 変更フロー
+
+1. `develop` から作業ブランチ（`feature/*` 等）を作成
+2. 作業ブランチで実装 → PR を `develop` へ作成 → マージ
+3. リリース時: `develop` から `release/x.y.z` を作成
+4. `scripts/bump_version.sh` でバージョン更新 → PR を `develop` へ作成 → マージ
+5. `develop` → `main` PR 作成 → マージ
+6. `main` で `scripts/create_release_tag.sh` → tag push → JSR publish 自動
+
+詳細は `/release-procedure` および `/branch-management` skill を参照。
+
 # release new version
 
 - run `scripts/bump_version.sh` when ordered.
   - do not speculate if it will release.
+- `bump_version.sh` updates deno.json only (no tag). Use `scripts/create_release_tag.sh` on main for tagging.
 
 # Claude Code Compay
 

--- a/deno.json
+++ b/deno.json
@@ -78,6 +78,8 @@
     "check": "deno check **/*.ts",
     "lint": "deno lint",
     "fmt": "deno fmt",
-    "ci": "scripts/local_ci.sh"
+    "ci": "scripts/local_ci.sh",
+    "bump-version": "scripts/bump_version.sh",
+    "create-tag": "scripts/create_release_tag.sh"
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@tettuan/breakdownconfig",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A Deno library for managing application and user configurations",
   "author": "tettuan",
   "license": "MIT",

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -1,74 +1,53 @@
 #!/bin/bash
 
-# Check if there are any uncommitted changes
-if [ -n "$(git status --porcelain)" ]; then
-    echo "Error: You have uncommitted changes. Please commit or stash them first."
+# Bump version in deno.json.
+# Usage:
+#   scripts/bump_version.sh          # detect version from release/* branch name
+#   scripts/bump_version.sh 1.3.0    # explicit version
+
+set -euo pipefail
+
+# Determine new version
+if [ $# -ge 1 ]; then
+  new_version="$1"
+else
+  branch=$(git branch --show-current)
+  if [[ "$branch" =~ ^release/(.+)$ ]]; then
+    new_version="${BASH_REMATCH[1]}"
+  else
+    echo "Error: Not on a release/* branch and no version argument provided."
+    echo "Usage: scripts/bump_version.sh [version]"
     exit 1
+  fi
 fi
 
-# Get the latest commit hash
-latest_commit=$(git rev-parse HEAD)
-
-# Check GitHub Actions status for all workflows
-echo "Checking GitHub Actions status..."
-for workflow in "test.yml" "version-check.yml"; do
-    echo "Checking $workflow..."
-    gh run list --workflow=$workflow --limit=1 --json status,conclusion,headSha | jq -e '.[0].status == "completed" and .[0].conclusion == "success" and .[0].headSha == "'$latest_commit'"' > /dev/null
-
-    if [ $? -ne 0 ]; then
-        echo "Error: Latest GitHub Actions workflow ($workflow) has not completed successfully."
-        echo "Please ensure all tests pass before bumping version."
-        exit 1
-    fi
-done
-
-# Try to get latest version from JSR
-echo "Checking latest version from JSR..."
-latest_jsr_version=$(curl -s https://jsr.io/@tettuan/breakdownconfig/meta.json | jq -r '.latestVersion')
-
-if [ -z "$latest_jsr_version" ] || [ "$latest_jsr_version" = "null" ]; then
-    echo "Warning: Could not determine latest version from JSR, using local version"
-    # Read current version from deno.json
-    latest_jsr_version=$(deno eval "const config = JSON.parse(await Deno.readTextFile('deno.json')); console.log(config.version);")
+# Validate version format
+if ! [[ "$new_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Error: Invalid version format '$new_version'. Expected x.y.z"
+  exit 1
 fi
 
-echo "Latest version: $latest_jsr_version"
+current_version=$(deno eval "console.log(JSON.parse(Deno.readTextFileSync('deno.json')).version)")
+echo "Current version: $current_version"
+echo "New version:     $new_version"
 
-# Get all GitHub tags to check for versions newer than JSR
-echo "Checking existing GitHub tags..."
-git fetch --tags
-all_tags=$(git tag -l "v*" | sort -V)
+if [ "$current_version" = "$new_version" ]; then
+  echo "Version is already $new_version. Nothing to do."
+  exit 0
+fi
 
-# Remove tags newer than JSR version
-for tag in $all_tags; do
-    tag_version=${tag#v}
-    if [ "$(printf '%s\n%s\n' "$tag_version" "$latest_jsr_version" | sort -V | tail -n 1)" = "$tag_version" ] && [ "$tag_version" != "$latest_jsr_version" ]; then
-        echo "Removing tag $tag (newer than JSR version $latest_jsr_version)"
-        git tag -d "$tag"
-        git push origin ":refs/tags/$tag"
-    fi
-done
+# Update deno.json
+deno eval "
+const config = JSON.parse(await Deno.readTextFile('deno.json'));
+config.version = '$new_version';
+await Deno.writeTextFile('deno.json', JSON.stringify(config, null, 2).trimEnd() + '\n');
+"
 
-echo "Using JSR version as base: $latest_jsr_version"
-
-# Split version into major.minor.patch
-IFS='.' read -r major minor patch <<< "$latest_jsr_version"
-
-# Increment patch version
-new_patch=$((patch + 1))
-new_version="$major.$minor.$new_patch"
-
-echo "New version: $new_version"
-
-# Update only the version in deno.json
-deno eval "const config = JSON.parse(await Deno.readTextFile('deno.json')); config.version = '$new_version'; await Deno.writeTextFile('deno.json', JSON.stringify(config, null, 2).trimEnd() + '\n');"
+echo "Updated deno.json to version $new_version"
 
 # Commit the version change
 git add deno.json
 git commit -m "chore: bump version to $new_version"
 
-# Create and push tag
-git tag "v$new_version"
-git push origin "v$new_version"
-
-echo "Version bumped to $new_version and tag v$new_version created" 
+echo "Version bumped to $new_version (committed, no tag created)"
+echo "Use scripts/create_release_tag.sh to create a tag on main after merging."

--- a/scripts/create_release_tag.sh
+++ b/scripts/create_release_tag.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Create a version tag on the main branch and push it.
+# The tag push triggers publish.yml for JSR publish.
+#
+# Usage:
+#   scripts/create_release_tag.sh          # read version from deno.json
+#   scripts/create_release_tag.sh 1.3.0    # explicit version
+
+set -euo pipefail
+
+# Ensure we are on main
+branch=$(git branch --show-current)
+if [ "$branch" != "main" ]; then
+  echo "Error: Must be on 'main' branch to create a release tag."
+  echo "Current branch: $branch"
+  exit 1
+fi
+
+# Ensure working tree is clean
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Error: Working tree is not clean. Commit or stash changes first."
+  exit 1
+fi
+
+# Determine version
+if [ $# -ge 1 ]; then
+  version="$1"
+else
+  version=$(deno eval "console.log(JSON.parse(Deno.readTextFileSync('deno.json')).version)")
+fi
+
+if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Error: Invalid version format '$version'. Expected x.y.z"
+  exit 1
+fi
+
+tag="v$version"
+
+# Check if tag already exists
+if git rev-parse "$tag" >/dev/null 2>&1; then
+  echo "Error: Tag '$tag' already exists."
+  exit 1
+fi
+
+echo "Creating tag: $tag"
+git tag "$tag"
+git push origin "$tag"
+
+echo "Tag $tag created and pushed."
+echo "This will trigger JSR publish via publish.yml."


### PR DESCRIPTION
## Summary
- Introduce Git Flow branch strategy (main / develop / release/* / feature/*)
- Rewrite bump_version.sh (branch name detection, no tag creation)
- Add create_release_tag.sh for main-only tagging
- Fix version-check.yml bugs (wrong JSR URL, outdated Deno setup)
- Update CI triggers for release/* and develop branches
- Update skills and CLAUDE.md to reflect branch strategy

## Version
- 1.2.2