### PR TITLE
Release 1.2.3: upgrade dependencies, update BreakdownLogger docs & skill

### DIFF
--- a/.claude/skills/breakdown-logger/SKILL.md
+++ b/.claude/skills/breakdown-logger/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: breakdown-logger
+description: Guide for using BreakdownLogger in test code. Use when writing tests, debugging test failures, or when user mentions 'logger', 'BreakdownLogger', 'LOG_LEVEL', 'LOG_KEY', 'LOG_LENGTH'.
+---
+
+# BreakdownLogger Usage Guide
+
+Package: `@tettuan/breakdownlogger@^1.1.2` (JSR)
+
+## Rules
+
+- BreakdownLogger is for **test files only**. Never use in production/library code (`src/`).
+- Production code is debugged through tests. If debugging production code is needed, add test code.
+
+## API Reference
+
+### Constructor
+
+```typescript
+import { BreakdownLogger } from "@tettuan/breakdownlogger";
+const logger = new BreakdownLogger(key?: string);
+```
+
+- `key`: Optional identifier for filtering logs (e.g. `"dataflow"`, `"security"`)
+
+### Methods
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| `debug()` | `message: string, data?: unknown` | Shown when `LOG_LEVEL=debug` |
+| `info()` | `message: string, data?: unknown` | Shown by default (level >= INFO) |
+| `warn()` | `message: string, data?: unknown` | Shown when `LOG_LEVEL=warn` or lower |
+| `error()` | `message: string, data?: unknown` | Always shown, output to stderr |
+
+### LogLevel Enum
+
+| Level | Value | Description |
+|-------|-------|-------------|
+| DEBUG | 0 | Detailed debug information (lowest) |
+| INFO | 1 | General informational (default) |
+| WARN | 2 | Potentially harmful situations |
+| ERROR | 3 | Error messages (highest, always shown) |
+
+### LogEntry Interface
+
+```typescript
+interface LogEntry {
+  message: string;    // Primary log text
+  level: LogLevel;    // Severity indicator
+  key: string;        // Logger identifier for filtering
+  data?: unknown;     // Structured contextual data
+  timestamp: Date;    // ISO 8601 formatted
+}
+```
+
+## Environment Variables
+
+| Variable | Values | Description |
+|----------|--------|-------------|
+| `LOG_LEVEL` | `debug`, `info`, `warn`, `error` | Severity threshold |
+| `LOG_KEY` | Comma-separated keys | Filter by logger key (e.g. `dataflow,security`) |
+| `LOG_LENGTH` | `S`, `L`, `W` | Output length: S=160, L=300, W=unlimited (default=80) |
+
+## Usage Patterns
+
+### Basic Test Logging
+
+```typescript
+import { BreakdownLogger } from "@tettuan/breakdownlogger";
+const logger = new BreakdownLogger();
+
+logger.debug("Test started", { testName, context });
+logger.error("Test failed", { error, expectedValue, actualValue });
+```
+
+### Purpose-Classified Loggers
+
+```typescript
+const dataflowLogger = new BreakdownLogger("dataflow");
+dataflowLogger.debug("Config loading started", { workingDir });
+
+const securityLogger = new BreakdownLogger("security");
+securityLogger.debug("File permissions checked", { path, mode });
+
+const stepLogger = new BreakdownLogger("stepbystep");
+stepLogger.debug("Phase 1 completed", { phase: "initialization" });
+
+const errorLogger = new BreakdownLogger("error");
+errorLogger.error("Validation failed", { field, expected, actual });
+```
+
+### Execution Commands
+
+```bash
+# Basic debug output
+LOG_LEVEL=debug deno test --allow-env --allow-write --allow-read
+
+# Filter by key
+LOG_LEVEL=debug LOG_KEY="dataflow" deno test --allow-env --allow-write --allow-read
+
+# Multiple keys
+LOG_LEVEL=debug LOG_KEY="dataflow,security" deno test --allow-env --allow-write --allow-read
+
+# Long output (300 chars)
+LOG_LEVEL=debug LOG_LENGTH=L deno test --allow-env --allow-write --allow-read
+
+# Whole output (unlimited)
+LOG_LEVEL=debug LOG_LENGTH=W deno test --allow-env --allow-write --allow-read
+
+# CI with error key
+DEBUG=true LOG_KEY="error" scripts/local_ci.sh
+```
+
+### Troubleshooting Formula
+
+1. `scripts/local_ci.sh` (overview)
+2. `DEBUG=true scripts/local_ci.sh` (detailed check)
+3. `LOG_LEVEL=debug deno test {file} --allow-env --allow-write --allow-read` (individual)
+4. `LOG_LEVEL=debug LOG_KEY="{key}" deno test {file} --allow-env --allow-write --allow-read` (filtered)
+5. `LOG_LEVEL=debug LOG_LENGTH=W deno test {file} --allow-env --allow-write --allow-read` (full output)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
 

--- a/deno.json
+++ b/deno.json
@@ -40,7 +40,29 @@
     ],
     "rules": {
       "tags": [
-        "recommended"
+        "recommended",
+        "jsr"
+      ],
+      "include": [
+        "ban-untagged-todo",
+        "camelcase",
+        "default-param-last",
+        "eqeqeq",
+        "explicit-function-return-type",
+        "explicit-module-boundary-types",
+        "guard-for-in",
+        "no-await-in-loop",
+        "no-boolean-literal-for-arguments",
+        "no-console",
+        "no-eval",
+        "no-non-null-assertion",
+        "no-self-compare",
+        "no-sync-fn-in-async-fn",
+        "no-throw-literal",
+        "no-top-level-await",
+        "no-inferrable-types",
+        "single-var-declarator",
+        "triple-slash-reference"
       ]
     }
   },
@@ -62,16 +84,16 @@
     "useTabs": false
   },
   "imports": {
-    "@std/assert": "jsr:@std/assert@^0.224.0",
-    "@std/assert/assert_equals": "jsr:@std/assert@^0.224.0/assert-equals",
-    "@std/assert/assert_rejects": "jsr:@std/assert@^0.224.0/assert-rejects",
-    "@std/testing": "jsr:@std/testing@^0.224.0",
-    "@std/testing/bdd": "jsr:@std/testing@^0.224.0/bdd",
-    "@std/path": "jsr:@std/path@^0.224.0",
-    "@std/yaml": "jsr:@std/yaml@^0.224.0",
-    "@std/fs": "jsr:@std/fs@^0.224.0",
-    "@std/expect": "jsr:@std/expect@^0.224.0",
-    "@tettuan/breakdownlogger": "jsr:@tettuan/breakdownlogger@^1.1.1"
+    "@std/assert": "jsr:@std/assert@^1.0.0",
+    "@std/assert/assert_equals": "jsr:@std/assert@^1.0.0/assert-equals",
+    "@std/assert/assert_rejects": "jsr:@std/assert@^1.0.0/assert-rejects",
+    "@std/testing": "jsr:@std/testing@^1.0.0",
+    "@std/testing/bdd": "jsr:@std/testing@^1.0.0/bdd",
+    "@std/path": "jsr:@std/path@^1.0.0",
+    "@std/yaml": "jsr:@std/yaml@^1.0.0",
+    "@std/fs": "jsr:@std/fs@^1.0.0",
+    "@std/expect": "jsr:@std/expect@^1.0.0",
+    "@tettuan/breakdownlogger": "jsr:@tettuan/breakdownlogger@^1.1.2"
   },
   "tasks": {
     "test": "deno test --allow-read --allow-write --allow-env",

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@tettuan/breakdownconfig",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "A Deno library for managing application and user configurations",
   "author": "tettuan",
   "license": "MIT",

--- a/docs/glossary.ja.md
+++ b/docs/glossary.ja.md
@@ -97,10 +97,13 @@
 
 ### BreakdownLogger
 
-- **定義**: ライブラリ専用のログ出力システム
+- **定義**: ライブラリ専用のログ出力システム (`@tettuan/breakdownlogger@^1.1.2`)
 - **用途**: テストコードのデバッグ、構造化ログの出力
-- **ログレベル**: DEBUG, INFO, WARN, ERROR
-- **制御**: 環境変数 `LOG_LEVEL` で制御可能
+- **ログレベル**: DEBUG (0), INFO (1), WARN (2), ERROR (3)
+- **環境変数**:
+  - `LOG_LEVEL`: 重要度の閾値 (`debug`, `info`, `warn`, `error`)
+  - `LOG_KEY`: ロガーキーでフィルタ (カンマ区切り、例: `dataflow,security`)
+  - `LOG_LENGTH`: 出力長 (`S`=160文字, `L`=300文字, `W`=無制限, デフォルト=80文字)
 
 ### ErrorManager
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -97,10 +97,13 @@
 
 ### BreakdownLogger
 
-- **Definition**: Library-specific log output system
+- **Definition**: Library-specific log output system (`@tettuan/breakdownlogger@^1.1.2`)
 - **Purpose**: Debug test code, output structured logs
-- **Log Levels**: DEBUG, INFO, WARN, ERROR
-- **Control**: Controllable by environment variable `LOG_LEVEL`
+- **Log Levels**: DEBUG (0), INFO (1), WARN (2), ERROR (3)
+- **Environment Variables**:
+  - `LOG_LEVEL`: Severity threshold (`debug`, `info`, `warn`, `error`)
+  - `LOG_KEY`: Filter by logger key (comma-separated, e.g. `dataflow,security`)
+  - `LOG_LENGTH`: Output length (`S`=160, `L`=300, `W`=unlimited, default=80)
 
 ### ErrorManager
 

--- a/docs/index.ja.md
+++ b/docs/index.ja.md
@@ -249,10 +249,13 @@ let devConfig = new BreakdownConfig("development");
 ## ログ出力の仕様
 
 - エラー管理（ErrorManager）でログ出力を行う
-- ログレベルは以下の通り
-  - DEBUG: デバッグ情報（テスト環境のみ）
-  - INFO: 通常の情報
-  - WARN: 警告情報
-  - ERROR: エラー情報
-- ログ出力は構造化データとして出力される
-- 環境変数 `LOG_LEVEL` でログレベルを制御可能
+- ログレベル（値が大きいほど重要度が高い）:
+  - DEBUG (0): デバッグ情報（テスト環境のみ）
+  - INFO (1): 通常の情報（デフォルト）
+  - WARN (2): 警告情報
+  - ERROR (3): エラー情報（常に表示、stderr出力）
+- ログ出力は構造化データとして出力される（LogEntry: timestamp, key, level, message, data）
+- 環境変数による制御:
+  - `LOG_LEVEL`: 重要度の閾値 (`debug`, `info`, `warn`, `error`)
+  - `LOG_KEY`: ロガーキーでフィルタ (カンマ区切り、例: `dataflow,security`)
+  - `LOG_LENGTH`: 出力長 (`S`=160文字, `L`=300文字, `W`=無制限, デフォルト=80文字)

--- a/docs/index.md
+++ b/docs/index.md
@@ -250,10 +250,13 @@ After loading configuration files, validates configuration file values.
 ## Log Output Specifications
 
 - Log output is performed by Error Manager (ErrorManager)
-- Log levels are as follows:
-  - DEBUG: Debug information (test environment only)
-  - INFO: Normal information
-  - WARN: Warning information
-  - ERROR: Error information
-- Log output is output as structured data
-- Log level can be controlled by environment variable `LOG_LEVEL`
+- Log levels (higher value = higher severity):
+  - DEBUG (0): Debug information (test environment only)
+  - INFO (1): Normal information (default)
+  - WARN (2): Warning information
+  - ERROR (3): Error information (always shown, stderr)
+- Log output is output as structured data (LogEntry with timestamp, key, level, message, data)
+- Environment variable controls:
+  - `LOG_LEVEL`: Severity threshold (`debug`, `info`, `warn`, `error`)
+  - `LOG_KEY`: Filter by logger key (comma-separated, e.g. `dataflow,security`)
+  - `LOG_LENGTH`: Output length (`S`=160, `L`=300, `W`=unlimited, default=80)

--- a/docs/tests.ja.md
+++ b/docs/tests.ja.md
@@ -91,8 +91,8 @@ LOG_LEVEL=debug LOG_KEY="security" deno test          # セキュリティ検証
 LOG_LEVEL=debug LOG_KEY="stepbystep" deno test        # ステップ追跡
 LOG_LEVEL=debug LOG_KEY="dataflow,security" deno test # 複数目的
 
-# 制限: LOG_LENGTH=数値
-LOG_LEVEL=debug LOG_LENGTH=200 deno test
+# 出力長: LOG_LENGTH={S|L|W} (Short=160文字, Long=300文字, Whole=無制限, デフォルト=80文字)
+LOG_LEVEL=debug LOG_LENGTH=L deno test
 
 # CI: DEBUG=true
 DEBUG=true LOG_KEY="error" scripts/local_ci.sh

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -91,8 +91,8 @@ LOG_LEVEL=debug LOG_KEY="security" deno test          # Security verification
 LOG_LEVEL=debug LOG_KEY="stepbystep" deno test        # Step tracking
 LOG_LEVEL=debug LOG_KEY="dataflow,security" deno test # Multiple purposes
 
-# Limit: LOG_LENGTH=number
-LOG_LEVEL=debug LOG_LENGTH=200 deno test
+# Output length: LOG_LENGTH={S|L|W} (Short=160, Long=300, Whole=unlimited, default=80)
+LOG_LEVEL=debug LOG_LENGTH=L deno test
 
 # CI: DEBUG=true
 DEBUG=true LOG_KEY="error" scripts/local_ci.sh

--- a/src/breakdown_config.ts
+++ b/src/breakdown_config.ts
@@ -4,7 +4,7 @@ import { ConfigManager } from "./config_manager.ts";
 import { AppConfigLoader } from "./loaders/app_config_loader.ts";
 import { UserConfigLoader } from "./loaders/user_config_loader.ts";
 import { Result } from "./types/unified_result.ts";
-import { ErrorFactories, UnifiedError } from "./errors/unified_errors.ts";
+import { ErrorFactories, type UnifiedError } from "./errors/unified_errors.ts";
 
 /**
  * Main configuration class for managing application and user settings.

--- a/src/breakdown_config_architecture_test.ts
+++ b/src/breakdown_config_architecture_test.ts
@@ -3,10 +3,15 @@
  * Level 0: Verifies architectural constraints and Total Function design patterns
  */
 
-import { assertEquals, assertExists, assertThrows as _assertThrows } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertExists,
+  type assertThrows as _assertThrows,
+} from "@std/assert";
 // import { BreakdownLogger } from "https://jsr.io/@tettuan/breakdownlogger";
 import { BreakdownConfig } from "./breakdown_config.ts";
-import { Result as _Result } from "./types/unified_result.ts";
+import type { Result as _Result } from "./types/unified_result.ts";
 
 // const logger = new BreakdownLogger("architecture");
 
@@ -21,7 +26,7 @@ Deno.test("Architecture: BreakdownConfig Smart Constructor Pattern", async (t) =
     // Note: TypeScript enforces private constructor at compile time
     // We verify the class can only be instantiated through create()
     const hasCreateMethod = typeof BreakdownConfig.create === "function";
-    assertEquals(hasCreateMethod, true, "Should only be created via create() method");
+    assert(hasCreateMethod, "Should only be created via create() method");
   });
 
   await t.step("Static create method should exist and return Result", () => {
@@ -36,7 +41,7 @@ Deno.test("Architecture: BreakdownConfig Smart Constructor Pattern", async (t) =
 
     // Should have success property (Result type signature)
     const hasSuccessProperty = "success" in result;
-    assertEquals(hasSuccessProperty, true, "Result should have success property");
+    assert(hasSuccessProperty, "Result should have success property");
 
     // logger.debug("Smart Constructor verification complete", {
     //   hasCreateMethod: true,
@@ -49,11 +54,11 @@ Deno.test("Architecture: BreakdownConfig Smart Constructor Pattern", async (t) =
 
     // Valid inputs should succeed
     const validResult = BreakdownConfig.create("production", "/valid/path");
-    assertEquals(validResult.success, true, "Valid inputs should succeed");
+    assert(validResult.success, "Valid inputs should succeed");
 
     // Invalid profile name should fail
     const invalidResult = BreakdownConfig.create("invalid@profile!", "/valid/path");
-    assertEquals(invalidResult.success, false, "Invalid profile should fail");
+    assert(!invalidResult.success, "Invalid profile should fail");
 
     if (!invalidResult.success) {
       assertExists(invalidResult.error, "Error should be provided for invalid input");
@@ -77,15 +82,15 @@ Deno.test("Architecture: BreakdownConfig Result Type Consistency", async (t) => 
 
     // Test loadConfigSafe returns Result
     const loadResult = await config.loadConfigSafe();
-    assertEquals("success" in loadResult, true, "loadConfigSafe should return Result");
+    assert("success" in loadResult, "loadConfigSafe should return Result");
 
     // Test getConfigSafe returns Result
     const getResult = await config.getConfigSafe();
-    assertEquals("success" in getResult, true, "getConfigSafe should return Result");
+    assert("success" in getResult, "getConfigSafe should return Result");
 
     // Test getWorkingDirSafe returns Result
     const workingDirResult = await config.getWorkingDirSafe();
-    assertEquals("success" in workingDirResult, true, "getWorkingDirSafe should return Result");
+    assert("success" in workingDirResult, "getWorkingDirSafe should return Result");
 
     // logger.debug("All Safe methods verified to return Result types");
   });
@@ -132,7 +137,7 @@ Deno.test("Architecture: BreakdownConfig Exception-Free Design", async (t) => {
         const result = BreakdownConfig.create(profile as string, baseDir as string);
         // Should always return a Result, never throw
         assertExists(result, `Should return Result for inputs: ${profile}, ${baseDir}`);
-        assertEquals("success" in result, true, "Should always return Result type");
+        assert("success" in result, "Should always return Result type");
       } catch (error) {
         throw new Error(
           `create() threw exception for inputs ${profile}, ${baseDir}: ${
@@ -182,7 +187,7 @@ Deno.test("Architecture: BreakdownConfig Total Function Compliance", async (t) =
     // logger.debug("Verifying total function behavior");
 
     const configResult = BreakdownConfig.create("test");
-    assertEquals(configResult.success, true, "Valid create should succeed");
+    assert(configResult.success, "Valid create should succeed");
 
     if (!configResult.success) {
       throw new Error("Test setup failed");

--- a/src/breakdown_config_structure_test.ts
+++ b/src/breakdown_config_structure_test.ts
@@ -3,10 +3,10 @@
  * Level 1: Verifies API contracts, method signatures, and type constraints
  */
 
-import { assertEquals, assertExists } from "@std/assert";
+import { assert, assertEquals, assertExists } from "@std/assert";
 import { BreakdownConfig } from "./breakdown_config.ts";
-import { Result as _Result } from "./types/unified_result.ts";
-import { UnifiedError as _UnifiedError } from "./errors/unified_errors.ts";
+import type { Result as _Result } from "./types/unified_result.ts";
+import type { UnifiedError as _UnifiedError } from "./errors/unified_errors.ts";
 
 // Logger removed for dependency simplification
 
@@ -47,19 +47,19 @@ Deno.test("Structure: BreakdownConfig API Contract Validation", async (t) => {
 
     // Safe methods should return Result types
     const loadResult = await config.loadConfigSafe();
-    assertEquals("success" in loadResult, true, "loadConfigSafe should return Result");
+    assert("success" in loadResult, "loadConfigSafe should return Result");
 
     const getResult = await config.getConfigSafe();
-    assertEquals("success" in getResult, true, "getConfigSafe should return Result");
+    assert("success" in getResult, "getConfigSafe should return Result");
 
     const workingDirResult = await config.getWorkingDirSafe();
-    assertEquals("success" in workingDirResult, true, "getWorkingDirSafe should return Result");
+    assert("success" in workingDirResult, "getWorkingDirSafe should return Result");
 
     const promptDirResult = await config.getPromptDirSafe();
-    assertEquals("success" in promptDirResult, true, "getPromptDirSafe should return Result");
+    assert("success" in promptDirResult, "getPromptDirSafe should return Result");
 
     const schemaDirResult = await config.getSchemaDirSafe();
-    assertEquals("success" in schemaDirResult, true, "getSchemaDirSafe should return Result");
+    assert("success" in schemaDirResult, "getSchemaDirSafe should return Result");
 
     // logger.debug("Instance method return types verified");
   });
@@ -90,21 +90,20 @@ Deno.test("Structure: BreakdownConfig Type Constraint Validation", async (t) => 
     const result = BreakdownConfig.create("test");
 
     // Result should have success property
-    assertEquals("success" in result, true, "Result should have success property");
+    assert("success" in result, "Result should have success property");
 
     if (result.success) {
       // Success result should have data property
       assertExists(result.data, "Success result should have data");
-      assertEquals(
+      assert(
         result.data instanceof BreakdownConfig,
-        true,
         "Data should be BreakdownConfig instance",
       );
     } else {
       // Error result should have error property
       assertExists(result.error, "Error result should have error");
-      assertEquals("kind" in result.error, true, "Error should have kind property");
-      assertEquals("message" in result.error, true, "Error should have message property");
+      assert("kind" in result.error, "Error should have kind property");
+      assert("message" in result.error, "Error should have message property");
     }
 
     // logger.debug("Result type constraints verified");
@@ -117,19 +116,19 @@ Deno.test("Structure: BreakdownConfig Type Constraint Validation", async (t) => 
     const validProfiles = ["test", "production", "development", "staging"];
     for (const profile of validProfiles) {
       const result = BreakdownConfig.create(profile);
-      assertEquals(result.success, true, `Profile "${profile}" should be valid`);
+      assert(result.success, `Profile "${profile}" should be valid`);
     }
 
     // Invalid profile names
     const invalidProfiles = ["test@invalid", "profile!", "test spaces"];
     for (const profile of invalidProfiles) {
       const result = BreakdownConfig.create(profile);
-      assertEquals(result.success, false, `Profile "${profile}" should be invalid`);
+      assert(!result.success, `Profile "${profile}" should be invalid`);
     }
 
     // Empty string is valid (defaults to no profile)
     const emptyResult = BreakdownConfig.create("");
-    assertEquals(emptyResult.success, true, "Empty profile should be valid (defaults)");
+    assert(emptyResult.success, "Empty profile should be valid (defaults)");
 
     // logger.debug("Profile name constraints verified");
   });
@@ -139,15 +138,14 @@ Deno.test("Structure: BreakdownConfig Type Constraint Validation", async (t) => 
 
     // Empty string should be handled gracefully
     const emptyDirResult = BreakdownConfig.create("test", "");
-    assertEquals(
+    assert(
       emptyDirResult.success,
-      true,
       "Empty base directory should default to current dir",
     );
 
     // Valid paths should work
     const validDirResult = BreakdownConfig.create("test", "/valid/path");
-    assertEquals(validDirResult.success, true, "Valid directory should be accepted");
+    assert(validDirResult.success, "Valid directory should be accepted");
 
     // logger.debug("Base directory constraints verified");
   });
@@ -212,8 +210,8 @@ Deno.test("Structure: BreakdownConfig Interface Consistency", async (t) => {
     const getResult = await config.getConfigSafe();
 
     // Both should return Results with same structure
-    assertEquals("success" in loadResult, true, "loadConfigSafe should return Result");
-    assertEquals("success" in getResult, true, "getConfigSafe should return Result");
+    assert("success" in loadResult, "loadConfigSafe should return Result");
+    assert("success" in getResult, "getConfigSafe should return Result");
 
     if (loadResult.success && getResult.success) {
       assertEquals(
@@ -235,7 +233,7 @@ Deno.test("Structure: BreakdownConfig Error Handling Structure", async (t) => {
 
     // Create error condition
     const errorResult = BreakdownConfig.create("invalid@profile");
-    assertEquals(errorResult.success, false, "Invalid profile should produce error");
+    assert(!errorResult.success, "Invalid profile should produce error");
 
     if (!errorResult.success) {
       const error: unknown = errorResult.error;

--- a/src/breakdown_config_units_test.ts
+++ b/src/breakdown_config_units_test.ts
@@ -3,7 +3,7 @@
  * Level 2: Verifies individual function behavior and business logic
  */
 
-import { assertEquals, assertExists, assertThrows } from "@std/assert";
+import { assert, assertEquals, assertExists, assertThrows } from "@std/assert";
 // import { BreakdownLogger } from "https://jsr.io/@tettuan/breakdownlogger";
 import { BreakdownConfig } from "./breakdown_config.ts";
 
@@ -17,24 +17,23 @@ Deno.test("Units: BreakdownConfig.create() Method Behavior", async (t) => {
 
     // No parameters (defaults)
     const defaultResult = BreakdownConfig.create();
-    assertEquals(defaultResult.success, true, "Default parameters should succeed");
+    assert(defaultResult.success, "Default parameters should succeed");
 
     if (defaultResult.success) {
       assertExists(defaultResult.data, "Success result should contain BreakdownConfig instance");
-      assertEquals(
+      assert(
         defaultResult.data instanceof BreakdownConfig,
-        true,
         "Data should be BreakdownConfig instance",
       );
     }
 
     // Valid profile only
     const profileResult = BreakdownConfig.create("production");
-    assertEquals(profileResult.success, true, "Valid profile should succeed");
+    assert(profileResult.success, "Valid profile should succeed");
 
     // Valid profile and baseDir
     const bothResult = BreakdownConfig.create("staging", "/valid/path");
-    assertEquals(bothResult.success, true, "Valid profile and baseDir should succeed");
+    assert(bothResult.success, "Valid profile and baseDir should succeed");
 
     // logger.debug("Valid parameter success cases verified");
   });
@@ -54,7 +53,7 @@ Deno.test("Units: BreakdownConfig.create() Method Behavior", async (t) => {
 
     for (const invalidProfile of invalidProfiles) {
       const result = BreakdownConfig.create(invalidProfile);
-      assertEquals(result.success, false, `Profile "${invalidProfile}" should be rejected`);
+      assert(!result.success, `Profile "${invalidProfile}" should be rejected`);
 
       if (!result.success) {
         assertExists(result.error, "Error result should contain error information");
@@ -85,7 +84,7 @@ Deno.test("Units: BreakdownConfig.create() Method Behavior", async (t) => {
 
     for (const validProfile of validProfiles) {
       const result = BreakdownConfig.create(validProfile);
-      assertEquals(result.success, true, `Profile "${validProfile}" should be accepted`);
+      assert(result.success, `Profile "${validProfile}" should be accepted`);
 
       if (result.success) {
         assertExists(result.data, "Success result should contain data");
@@ -101,7 +100,7 @@ Deno.test("Units: BreakdownConfig.create() Method Behavior", async (t) => {
 
     // Empty string baseDir should be valid (defaults to current dir)
     const emptyDirResult = BreakdownConfig.create("test", "");
-    assertEquals(emptyDirResult.success, true, "Empty baseDir should be valid (defaults)");
+    assert(emptyDirResult.success, "Empty baseDir should be valid (defaults)");
 
     // logger.debug("Invalid baseDir handling verified");
   });
@@ -129,7 +128,7 @@ Deno.test("Units: BreakdownConfig.create() Method Behavior", async (t) => {
       try {
         const result = BreakdownConfig.create(profile, baseDir);
         assertExists(result, `Should return Result for inputs: ${profile}, ${baseDir}`);
-        assertEquals("success" in result, true, "Should always return Result type");
+        assert("success" in result, "Should always return Result type");
         // logger.debug(`Exception-free behavior verified for inputs: ${profile}, ${baseDir}`);
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
@@ -152,9 +151,8 @@ Deno.test("Units: BreakdownConfig.createLegacy() Method Behavior", async (t) => 
     // No parameters
     const defaultLegacy = BreakdownConfig.createLegacy();
     assertExists(defaultLegacy, "createLegacy should work with no parameters");
-    assertEquals(
+    assert(
       defaultLegacy instanceof BreakdownConfig,
-      true,
       "Should return BreakdownConfig instance",
     );
 
@@ -195,14 +193,12 @@ Deno.test("Units: BreakdownConfig.createLegacy() Method Behavior", async (t) => 
 
       if (modernResult.success) {
         // Both should be BreakdownConfig instances
-        assertEquals(
+        assert(
           modernResult.data instanceof BreakdownConfig,
-          true,
           "Modern should create BreakdownConfig",
         );
-        assertEquals(
+        assert(
           legacyInstance instanceof BreakdownConfig,
-          true,
           "Legacy should create BreakdownConfig",
         );
 
@@ -240,14 +236,14 @@ Deno.test("Units: BreakdownConfig loadConfigSafe() Functionality", async (t) => 
 
     // Should always return Result
     assertExists(loadResult, "loadConfigSafe should return defined value");
-    assertEquals("success" in loadResult, true, "Should return Result type");
+    assert("success" in loadResult, "Should return Result type");
 
     if (loadResult.success) {
       assertExists(loadResult.data, "Success result should have data");
       // logger.debug("loadConfigSafe success case verified");
     } else {
       assertExists(loadResult.error, "Error result should have error");
-      assertEquals("kind" in loadResult.error, true, "Error should have kind property");
+      assert("kind" in loadResult.error, "Error should have kind property");
       // logger.debug("loadConfigSafe error case verified", { errorKind: loadResult.error.kind });
     }
 
@@ -267,9 +263,10 @@ Deno.test("Units: BreakdownConfig loadConfigSafe() Functionality", async (t) => 
     for (const configResult of problemConfigs) {
       if (configResult.success) {
         try {
+          // deno-lint-ignore no-await-in-loop
           const loadResult = await configResult.data.loadConfigSafe();
           assertExists(loadResult, "loadConfigSafe should return Result even for problems");
-          assertEquals("success" in loadResult, true, "Should return Result type structure");
+          assert("success" in loadResult, "Should return Result type structure");
           // logger.debug("loadConfigSafe handled potential problem gracefully");
         } catch (error) {
           throw new Error(`loadConfigSafe threw exception: ${error}`);
@@ -330,7 +327,7 @@ Deno.test("Units: BreakdownConfig getConfigSafe() Functionality", async (t) => {
 
     // Should return Result type
     assertExists(getResult, "getConfigSafe should return defined value");
-    assertEquals("success" in getResult, true, "Should return Result type");
+    assert("success" in getResult, "Should return Result type");
 
     if (getResult.success) {
       assertExists(getResult.data, "Success should contain configuration data");
@@ -361,16 +358,15 @@ Deno.test("Units: BreakdownConfig getConfigSafe() Functionality", async (t) => {
     // Success/failure should be related
     if (loadResult.success) {
       // If load succeeded, get should also succeed (or be consistent)
-      assertEquals(
+      assert(
         "success" in getResult,
-        true,
         "getConfigSafe should return Result after successful load",
       );
     }
 
     // Both should follow same Result pattern
-    assertEquals("success" in loadResult, true, "loadConfigSafe should return Result");
-    assertEquals("success" in getResult, true, "getConfigSafe should return Result");
+    assert("success" in loadResult, "loadConfigSafe should return Result");
+    assert("success" in getResult, "getConfigSafe should return Result");
 
     // logger.debug("getConfigSafe/loadConfigSafe consistency verified");
   });
@@ -390,11 +386,11 @@ Deno.test("Units: BreakdownConfig Directory Retrieval Methods", async (t) => {
     const config = configResult.data;
     const workingDirResult = await config.getWorkingDirSafe();
 
-    assertEquals("success" in workingDirResult, true, "Should return Result type");
+    assert("success" in workingDirResult, "Should return Result type");
 
     if (workingDirResult.success) {
       assertEquals(typeof workingDirResult.data, "string", "Working directory should be string");
-      assertEquals(workingDirResult.data.length > 0, true, "Working directory should not be empty");
+      assert(workingDirResult.data.length > 0, "Working directory should not be empty");
       // logger.debug("getWorkingDirSafe success verified", { workingDir: workingDirResult.data });
     }
 
@@ -412,11 +408,11 @@ Deno.test("Units: BreakdownConfig Directory Retrieval Methods", async (t) => {
     const config = configResult.data;
     const promptDirResult = await config.getPromptDirSafe();
 
-    assertEquals("success" in promptDirResult, true, "Should return Result type");
+    assert("success" in promptDirResult, "Should return Result type");
 
     if (promptDirResult.success) {
       assertEquals(typeof promptDirResult.data, "string", "Prompt directory should be string");
-      assertEquals(promptDirResult.data.length > 0, true, "Prompt directory should not be empty");
+      assert(promptDirResult.data.length > 0, "Prompt directory should not be empty");
       // logger.debug("getPromptDirSafe success verified", { promptDir: promptDirResult.data });
     }
 
@@ -434,11 +430,11 @@ Deno.test("Units: BreakdownConfig Directory Retrieval Methods", async (t) => {
     const config = configResult.data;
     const schemaDirResult = await config.getSchemaDirSafe();
 
-    assertEquals("success" in schemaDirResult, true, "Should return Result type");
+    assert("success" in schemaDirResult, "Should return Result type");
 
     if (schemaDirResult.success) {
       assertEquals(typeof schemaDirResult.data, "string", "Schema directory should be string");
-      assertEquals(schemaDirResult.data.length > 0, true, "Schema directory should not be empty");
+      assert(schemaDirResult.data.length > 0, "Schema directory should not be empty");
       // logger.debug("getSchemaDirSafe success verified", { schemaDir: schemaDirResult.data });
     }
 
@@ -461,9 +457,9 @@ Deno.test("Units: BreakdownConfig Directory Retrieval Methods", async (t) => {
     const schemaDirResult = await config.getSchemaDirSafe();
 
     // All should return Results
-    assertEquals("success" in workingDirResult, true, "Working dir should return Result");
-    assertEquals("success" in promptDirResult, true, "Prompt dir should return Result");
-    assertEquals("success" in schemaDirResult, true, "Schema dir should return Result");
+    assert("success" in workingDirResult, "Working dir should return Result");
+    assert("success" in promptDirResult, "Prompt dir should return Result");
+    assert("success" in schemaDirResult, "Schema dir should return Result");
 
     // If all succeed, they should be valid paths
     if (workingDirResult.success && promptDirResult.success && schemaDirResult.success) {
@@ -472,9 +468,9 @@ Deno.test("Units: BreakdownConfig Directory Retrieval Methods", async (t) => {
       assertEquals(typeof schemaDirResult.data, "string", "Schema dir should be string");
 
       // All should be non-empty
-      assertEquals(workingDirResult.data.length > 0, true, "Working dir should not be empty");
-      assertEquals(promptDirResult.data.length > 0, true, "Prompt dir should not be empty");
-      assertEquals(schemaDirResult.data.length > 0, true, "Schema dir should not be empty");
+      assert(workingDirResult.data.length > 0, "Working dir should not be empty");
+      assert(promptDirResult.data.length > 0, "Prompt dir should not be empty");
+      assert(schemaDirResult.data.length > 0, "Schema dir should not be empty");
     }
 
     // logger.debug("Directory method consistency verified");

--- a/src/config_manager.ts
+++ b/src/config_manager.ts
@@ -1,11 +1,11 @@
-import { AppConfigLoader } from "./loaders/app_config_loader.ts";
-import { UserConfigLoader } from "./loaders/user_config_loader.ts";
+import type { AppConfigLoader } from "./loaders/app_config_loader.ts";
+import type { UserConfigLoader } from "./loaders/user_config_loader.ts";
 import type { AppConfig } from "./types/app_config.ts";
 import type { LegacyUserConfig, UserConfig } from "./types/user_config.ts";
 import { UserConfigFactory, UserConfigGuards } from "./types/user_config.ts";
 import type { MergedConfig } from "./types/merged_config.ts";
 import { Result } from "./types/unified_result.ts";
-import { ErrorFactories, UnifiedError } from "./errors/unified_errors.ts";
+import { ErrorFactories, type UnifiedError } from "./errors/unified_errors.ts";
 import type { ValidationError } from "./types/config_result.ts";
 
 /**
@@ -363,16 +363,16 @@ export class ConfigManager {
 
       // Start with complete app config as base - ensuring ALL fields are preserved
       const mergedConfig: MergedConfig = {
-        working_dir: String(appConfigCopy.working_dir || ""),
-        app_prompt: {
-          base_dir: this.safeGetBaseDir(appConfigCopy.app_prompt),
+        "working_dir": String(appConfigCopy.working_dir || ""),
+        "app_prompt": {
+          "base_dir": this.safeGetBaseDir(appConfigCopy.app_prompt),
           // Deep clone additional app_prompt fields to prevent reference issues
           ...this.deepCloneNestedFields(appConfigCopy.app_prompt as Record<string, unknown>, [
             "base_dir",
           ]),
         },
-        app_schema: {
-          base_dir: this.safeGetBaseDir(appConfigCopy.app_schema),
+        "app_schema": {
+          "base_dir": this.safeGetBaseDir(appConfigCopy.app_schema),
           // Deep clone additional app_schema fields to prevent reference issues
           ...this.deepCloneNestedFields(appConfigCopy.app_schema as Record<string, unknown>, [
             "base_dir",
@@ -405,7 +405,7 @@ export class ConfigManager {
    */
   private safeGetBaseDir(configObj: unknown): string {
     // Handle null or undefined
-    if (configObj == null) {
+    if (configObj === null || configObj === undefined) {
       return "";
     }
 

--- a/src/config_manager_architecture_test.ts
+++ b/src/config_manager_architecture_test.ts
@@ -3,7 +3,7 @@
  * Level 0: Verifies state machine design and Discriminated Union patterns
  */
 
-import { assertEquals, assertExists } from "@std/assert";
+import { assert, assertEquals, assertExists } from "@std/assert";
 import { BreakdownLogger } from "@tettuan/breakdownlogger";
 import { ConfigManager } from "./config_manager.ts";
 import { AppConfigLoader } from "./loaders/app_config_loader.ts";
@@ -24,7 +24,7 @@ Deno.test("Architecture: ConfigManager State Machine Pattern", async (t) => {
     // Test initial state by calling methods
     const initialResult = await manager.getConfigSafe();
     assertExists(initialResult, "getConfigSafe should return Result");
-    assertEquals("success" in initialResult, true, "Should return Result type");
+    assert("success" in initialResult, "Should return Result type");
 
     logger.debug("State machine pattern verified");
   });
@@ -63,7 +63,7 @@ Deno.test("Architecture: ConfigManager Result Type Consistency", async (t) => {
 
     // Test getConfigSafe returns Result
     const configResult = await manager.getConfigSafe();
-    assertEquals("success" in configResult, true, "getConfigSafe should return Result");
+    assert("success" in configResult, "getConfigSafe should return Result");
 
     logger.debug("Result type consistency verified");
   });
@@ -79,7 +79,7 @@ Deno.test("Architecture: ConfigManager Result Type Consistency", async (t) => {
     try {
       const result = await manager.getConfigSafe();
       assertExists(result, "Should return Result even for errors");
-      assertEquals("success" in result, true, "Should return Result type structure");
+      assert("success" in result, "Should return Result type structure");
 
       if (!result.success) {
         assertExists(result.error, "Error Result should contain error information");
@@ -208,13 +208,13 @@ Deno.test("Architecture: ConfigManager Total Function Compliance", async (t) => 
     // All calls should return Result types
     calls.forEach((result, index) => {
       assertExists(result, `Call ${index} should return defined Result`);
-      assertEquals("success" in result, true, `Call ${index} should return Result type`);
+      assert("success" in result, `Call ${index} should return Result type`);
     });
 
     // State should be consistent across calls
     const successStates = calls.map((r) => r.success);
     const allSameState = successStates.every((state) => state === successStates[0]);
-    assertEquals(allSameState, true, "State should be consistent across multiple calls");
+    assert(allSameState, "State should be consistent across multiple calls");
 
     logger.debug("State transition predictability verified");
   });

--- a/src/errors/config_manager_errors.ts
+++ b/src/errors/config_manager_errors.ts
@@ -5,8 +5,8 @@
  * ファクトリ関数とメッセージテンプレートを提供
  */
 
-import { ErrorFactories, UnifiedError } from "./unified_errors.ts";
-import { errorManager, SupportedLanguage } from "./unified_error_manager.ts";
+import { ErrorFactories, type UnifiedError } from "./unified_errors.ts";
+import { errorManager, type SupportedLanguage } from "./unified_error_manager.ts";
 
 /**
  * ConfigManager固有のエラーコンテキスト
@@ -34,9 +34,9 @@ export const ConfigManagerErrors = {
    */
   configFileNotFound: (
     path: string,
-    configType: "app" | "user" = "app",
     searchedLocations?: string[],
     _context?: ConfigManagerContext,
+    configType: "app" | "user" = "app",
   ): UnifiedError => {
     return ErrorFactories.configFileNotFound(path, configType, searchedLocations);
   },

--- a/src/errors/enhanced_i18n_system.ts
+++ b/src/errors/enhanced_i18n_system.ts
@@ -7,7 +7,7 @@
  */
 
 import { ErrorCodeRegistry, StandardErrorCode } from "./standardized_error_codes.ts";
-import {
+import type {
   BaseErrorInterface,
   ErrorCategory as _ErrorCategory,
   ErrorSeverity as _ErrorSeverity,

--- a/src/errors/error_code_mapping.ts
+++ b/src/errors/error_code_mapping.ts
@@ -4,7 +4,7 @@
  */
 
 import { ErrorCode } from "../error_manager.ts";
-import { ErrorFactories, UnifiedError } from "./unified_errors.ts";
+import { ErrorFactories, type UnifiedError } from "./unified_errors.ts";
 
 /**
  * Maps legacy ErrorCode values to appropriate UnifiedError factory functions

--- a/src/errors/error_handling_utils.ts
+++ b/src/errors/error_handling_utils.ts
@@ -3,14 +3,14 @@
  * Provides helper functions for error type conversions and handling
  */
 
-import { ErrorFactories, UnifiedError } from "./unified_errors.ts";
+import { ErrorFactories, type UnifiedError } from "./unified_errors.ts";
 import {
-  BaseErrorInterface,
+  type BaseErrorInterface,
   ErrorCategory,
   ErrorSeverity,
   StandardErrorCode,
 } from "./unified_error_interface.ts";
-import { Result as _Result } from "../types/unified_result.ts";
+import type { Result as _Result } from "../types/unified_result.ts";
 
 /**
  * Error handling utilities

--- a/src/errors/i18n_message_system.ts
+++ b/src/errors/i18n_message_system.ts
@@ -8,7 +8,7 @@
  * 4. 型安全なメッセージ定義
  */
 
-import { ErrorCode } from "../error_manager.ts";
+import type { ErrorCode } from "../error_manager.ts";
 
 // サポート言語
 export type SupportedLanguage = "en" | "ja";

--- a/src/errors/legacy_adapter.ts
+++ b/src/errors/legacy_adapter.ts
@@ -5,8 +5,11 @@
  * while maintaining backward compatibility during the transition period.
  */
 
-import { ConfigError, PathErrorReason as LegacyPathErrorReason } from "../types/config_result.ts";
-import { ErrorFactories, PathErrorReason, UnifiedError } from "./unified_errors.ts";
+import type {
+  ConfigError,
+  PathErrorReason as LegacyPathErrorReason,
+} from "../types/config_result.ts";
+import { ErrorFactories, type PathErrorReason, type UnifiedError } from "./unified_errors.ts";
 
 /**
  * Maps legacy PathErrorReason to new PathErrorReason

--- a/src/errors/polymorphic_error_system.ts
+++ b/src/errors/polymorphic_error_system.ts
@@ -6,17 +6,17 @@
  */
 
 import {
-  BaseErrorInterface,
-  ErrorAggregator as _ErrorAggregator,
+  type BaseErrorInterface,
+  type ErrorAggregator as _ErrorAggregator,
   ErrorCategory,
-  ErrorFactory,
-  ErrorHandler,
-  ErrorMetrics as _ErrorMetrics,
-  ErrorReporter as _ErrorReporter,
-  ErrorSerializer as _ErrorSerializer,
+  type ErrorFactory,
+  type ErrorHandler,
+  type ErrorMetrics as _ErrorMetrics,
+  type ErrorReporter as _ErrorReporter,
+  type ErrorSerializer as _ErrorSerializer,
   ErrorSeverity,
-  ErrorTransformer as _ErrorTransformer,
-  ErrorValidator as _ErrorValidator,
+  type ErrorTransformer as _ErrorTransformer,
+  type ErrorValidator as _ErrorValidator,
   StandardErrorCode,
 } from "./unified_error_interface.ts";
 
@@ -241,8 +241,8 @@ export class RequiredFieldMissingError extends ValidationError {
   constructor(
     field: string,
     public readonly parentObject?: string,
-    public readonly availableFields: string[] = [],
     context?: Record<string, unknown>,
+    public readonly availableFields: string[] = [],
   ) {
     super(
       `Required field is missing`,
@@ -542,9 +542,10 @@ export class PolymorphicErrorHandlerRegistry {
       this.handlers.set(errorKind, []);
     }
 
-    const handlers = this.handlers.get(errorKind)!;
+    const handlers = this.handlers.get(errorKind) ?? [];
     handlers.push(handler);
     handlers.sort((a, b) => b.priority - a.priority);
+    this.handlers.set(errorKind, handlers);
   }
 
   /**
@@ -565,6 +566,7 @@ export class PolymorphicErrorHandlerRegistry {
     for (const handler of kindHandlers) {
       if (handler.canHandle(error)) {
         try {
+          // deno-lint-ignore no-await-in-loop
           const result = await handler.handle(error);
           if (result === undefined) return; // Successfully handled
           if (result !== error) return result; // Transformed error
@@ -578,6 +580,7 @@ export class PolymorphicErrorHandlerRegistry {
     for (const handler of this.globalHandlers) {
       if (handler.canHandle(error)) {
         try {
+          // deno-lint-ignore no-await-in-loop
           const result = await handler.handle(error);
           if (result === undefined) return; // Successfully handled
           if (result !== error) return result; // Transformed error
@@ -773,7 +776,7 @@ export const createError = {
     new ConfigParseError(path, syntaxError, line, column),
 
   requiredFieldMissing: (field: string, parentObject?: string, availableFields?: string[]) =>
-    new RequiredFieldMissingError(field, parentObject, availableFields),
+    new RequiredFieldMissingError(field, parentObject, undefined, availableFields),
 
   typeMismatch: (field: string, expectedType: string, actualType: string, value: unknown) =>
     new TypeMismatchError(field, expectedType, actualType, value),

--- a/src/errors/throw_to_result.ts
+++ b/src/errors/throw_to_result.ts
@@ -4,7 +4,7 @@
  */
 
 import { Result } from "../types/unified_result.ts";
-import { ErrorFactories, UnifiedError } from "./unified_errors.ts";
+import { ErrorFactories, type UnifiedError } from "./unified_errors.ts";
 import { ErrorCode } from "../error_manager.ts";
 
 /**

--- a/src/errors/unified_error_i18n.ts
+++ b/src/errors/unified_error_i18n.ts
@@ -8,7 +8,7 @@
  * - パラメータ置換サポート
  */
 
-import {
+import type {
   ConfigError,
   PathErrorReason as _PathErrorReason,
   ValidationError as _ValidationError,

--- a/src/errors/unified_error_implementation.ts
+++ b/src/errors/unified_error_implementation.ts
@@ -7,28 +7,28 @@
  */
 
 import {
-  BaseErrorInterface,
-  ErrorAggregator,
+  type BaseErrorInterface,
+  type ErrorAggregator,
   ErrorCategory,
-  ErrorConfiguration,
-  ErrorContext as _ErrorContext,
-  ErrorFactory,
-  ErrorHandler,
-  ErrorI18nConfig,
-  ErrorLifecycleHooks,
-  ErrorMetrics,
-  ErrorRecoveryStrategy as _ErrorRecoveryStrategy,
-  ErrorReporter,
-  ErrorSerializer,
+  type ErrorConfiguration,
+  type ErrorContext as _ErrorContext,
+  type ErrorFactory,
+  type ErrorHandler,
+  type ErrorI18nConfig,
+  type ErrorLifecycleHooks,
+  type ErrorMetrics,
+  type ErrorRecoveryStrategy as _ErrorRecoveryStrategy,
+  type ErrorReporter,
+  type ErrorSerializer,
   ErrorSeverity,
-  ErrorTransformer as _ErrorTransformer,
-  ErrorValidator,
+  type ErrorTransformer as _ErrorTransformer,
+  type ErrorValidator,
   StandardErrorCode,
-  UnifiedErrorManager,
+  type UnifiedErrorManager,
 } from "./unified_error_interface.ts";
 
 import {
-  AbstractError as _AbstractError,
+  type AbstractError as _AbstractError,
   createError,
   ErrorChainBuilder,
   makeErrorVisitable,
@@ -38,25 +38,25 @@ import {
 
 import {
   enhancedI18n,
-  EnhancedI18nManager as _EnhancedI18nManager,
+  type EnhancedI18nManager as _EnhancedI18nManager,
   ErrorMessageUtils,
-  MessageContext,
-  MessageParams,
-  SupportedLanguage,
+  type MessageContext,
+  type MessageParams,
+  type SupportedLanguage,
 } from "./enhanced_i18n_system.ts";
 
-import {
+import type {
   ErrorCodeRegistry as _ErrorCodeRegistry,
   ErrorCodeUtils as _ErrorCodeUtils,
 } from "./standardized_error_codes.ts";
-import { UnifiedError } from "./unified_errors.ts";
+import type { UnifiedError } from "./unified_errors.ts";
 
 /**
  * Production-ready error aggregator implementation
  */
 export class ProductionErrorAggregator implements ErrorAggregator {
   private errors: BaseErrorInterface[] = [];
-  private maxErrors: number = 1000;
+  private maxErrors = 1000;
 
   constructor(maxErrors = 1000) {
     this.maxErrors = maxErrors;
@@ -601,20 +601,25 @@ export const unifiedErrorManager = new CompleteUnifiedErrorManager({
 });
 
 /**
+ * Create and process error in one call
+ */
+async function createAndProcessImpl<T extends BaseErrorInterface>(
+  errorType: string,
+  params: unknown,
+): Promise<T> {
+  const error = unifiedErrorManager.createError<T>(errorType, params);
+  await unifiedErrorManager.processError(error);
+  return error;
+}
+
+/**
  * Convenience functions for common error operations
  */
 export const ErrorUtils = {
   /**
    * Create and process error in one call
    */
-  async createAndProcess<T extends BaseErrorInterface>(
-    errorType: string,
-    params: unknown,
-  ): Promise<T> {
-    const error = unifiedErrorManager.createError<T>(errorType, params);
-    await unifiedErrorManager.processError(error);
-    return error;
-  },
+  createAndProcess: createAndProcessImpl,
 
   /**
    * Convert any error to unified error

--- a/src/errors/unified_error_manager.ts
+++ b/src/errors/unified_error_manager.ts
@@ -8,7 +8,11 @@
  * - デバッグ情報とユーザー向け情報の分離
  */
 
-import { ErrorFactories, ErrorGuards as _ErrorGuards, UnifiedError } from "./unified_errors.ts";
+import {
+  ErrorFactories,
+  type ErrorGuards as _ErrorGuards,
+  type UnifiedError,
+} from "./unified_errors.ts";
 import { Result } from "../types/unified_result.ts";
 
 /**

--- a/src/loaders/app_config_loader.ts
+++ b/src/loaders/app_config_loader.ts
@@ -1,7 +1,12 @@
 import { join } from "@std/path";
 import type { AppConfig } from "../types/app_config.ts";
 import { DefaultPaths } from "../types/app_config.ts";
-import { ConfigError, ConfigResult, Result, ValidationError } from "../types/config_result.ts";
+import {
+  type ConfigError,
+  type ConfigResult,
+  Result,
+  type ValidationError,
+} from "../types/config_result.ts";
 import { SafeConfigLoader } from "./safe_config_loader.ts";
 import { ConfigValidator } from "../validators/config_validator.ts";
 

--- a/src/loaders/base_loader.ts
+++ b/src/loaders/base_loader.ts
@@ -1,8 +1,8 @@
 import { parse as parseYaml } from "@std/yaml";
 import { join } from "@std/path";
 import {
-  ConfigError,
-  ConfigResult,
+  type ConfigError,
+  type ConfigResult,
   type FileNotFoundError,
   type ParseError,
   Result,

--- a/src/loaders/profile_config_loader.ts
+++ b/src/loaders/profile_config_loader.ts
@@ -87,6 +87,7 @@ export class ProfileConfigLoader {
     // Check if user config exists and is valid
     if (userResult.success && userResult.data !== null && Object.keys(userResult.data).length > 0) {
       // User config exists and loaded successfully - return MergedProfile
+      const userData = userResult.data as UserConfig;
       const mergedProfile: MergedProfile = {
         kind: "merged",
         profileName: this.profileName,
@@ -95,7 +96,7 @@ export class ProfileConfigLoader {
           userConfigPath: this.getUserConfigPath(),
           userConfigExists: true,
         },
-        config: this.mergeConfigs(appConfig, userResult.data!),
+        config: this.mergeConfigs(appConfig, userData),
       };
       return UnifiedResult.ok(mergedProfile);
     } else {
@@ -109,12 +110,12 @@ export class ProfileConfigLoader {
           userConfigExists: false,
         },
         config: {
-          working_dir: appConfig.working_dir,
-          app_prompt: {
-            base_dir: appConfig.app_prompt.base_dir,
+          "working_dir": appConfig.working_dir,
+          "app_prompt": {
+            "base_dir": appConfig.app_prompt.base_dir,
           },
-          app_schema: {
-            base_dir: appConfig.app_schema.base_dir,
+          "app_schema": {
+            "base_dir": appConfig.app_schema.base_dir,
           },
         },
       };
@@ -128,12 +129,12 @@ export class ProfileConfigLoader {
   private mergeConfigs(appConfig: AppConfig, userConfig: UserConfig): MergedProfile["config"] {
     // Start with app config as base
     const merged: MergedProfile["config"] = {
-      working_dir: appConfig.working_dir,
-      app_prompt: {
-        base_dir: appConfig.app_prompt.base_dir,
+      "working_dir": appConfig.working_dir,
+      "app_prompt": {
+        "base_dir": appConfig.app_prompt.base_dir,
       },
-      app_schema: {
-        base_dir: appConfig.app_schema.base_dir,
+      "app_schema": {
+        "base_dir": appConfig.app_schema.base_dir,
       },
     };
 

--- a/src/loaders/safe_config_loader.ts
+++ b/src/loaders/safe_config_loader.ts
@@ -1,7 +1,7 @@
 import { parse as parseYaml } from "@std/yaml";
 import {
-  ConfigError,
-  ConfigResult,
+  type ConfigError,
+  type ConfigResult,
   type FileNotFoundError,
   type ParseError,
   Result,

--- a/src/loaders/user_config_loader.ts
+++ b/src/loaders/user_config_loader.ts
@@ -1,6 +1,6 @@
 import { join } from "@std/path";
 import { parse as parseYaml } from "@std/yaml";
-import {
+import type {
   ErrorCode as _ErrorCodeLoader,
   ErrorManager as _ErrorManagerLoader,
 } from "../error_manager.ts";
@@ -8,12 +8,12 @@ import type { LegacyUserConfig, UserConfig } from "../types/user_config.ts";
 import { UserConfigFactory } from "../types/user_config.ts";
 import { DefaultPaths } from "../types/app_config.ts";
 import {
-  ConfigResult,
-  FileNotFoundError as _FileNotFoundErrorLoader,
-  ParseError,
+  type ConfigResult,
+  type FileNotFoundError as _FileNotFoundErrorLoader,
+  type ParseError,
   Result,
-  UnknownError,
-  ValidationError as _ValidationErrorLoader,
+  type UnknownError,
+  type ValidationError as _ValidationErrorLoader,
 } from "../types/config_result.ts";
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,18 +10,18 @@
  */
 interface AppConfig {
   /** Working directory for the application */
-  working_dir: string;
+  "working_dir": string;
   /** Prompt configuration settings */
-  app_prompt: {
+  "app_prompt": {
     /** Base directory for prompt files */
-    base_dir: string;
+    "base_dir": string;
     /** List of prompt files */
     files?: string[];
   };
   /** Schema configuration settings */
-  app_schema: {
+  "app_schema": {
     /** Base directory for schema files */
-    base_dir: string;
+    "base_dir": string;
     /** List of schema files */
     files?: string[];
   };
@@ -34,18 +34,18 @@ interface AppConfig {
  */
 interface UserConfig {
   /** Optional working directory override */
-  working_dir?: string;
+  "working_dir"?: string;
   /** Optional prompt configuration overrides */
-  app_prompt?: {
+  "app_prompt"?: {
     /** Base directory for prompt files */
-    base_dir?: string;
+    "base_dir"?: string;
     /** List of prompt files */
     files?: string[];
   };
   /** Optional schema configuration overrides */
-  app_schema?: {
+  "app_schema"?: {
     /** Base directory for schema files */
-    base_dir?: string;
+    "base_dir"?: string;
     /** List of schema files */
     files?: string[];
   };
@@ -58,18 +58,18 @@ interface UserConfig {
  */
 interface MergedConfig {
   /** Working directory for the application */
-  working_dir: string;
+  "working_dir": string;
   /** Prompt configuration settings */
-  app_prompt: {
+  "app_prompt": {
     /** Base directory for prompt files */
-    base_dir: string;
+    "base_dir": string;
     /** List of prompt files */
     files?: string[];
   };
   /** Schema configuration settings */
-  app_schema: {
+  "app_schema": {
     /** Base directory for schema files */
-    base_dir: string;
+    "base_dir": string;
     /** List of schema files */
     files?: string[];
   };

--- a/src/types/app_config.ts
+++ b/src/types/app_config.ts
@@ -17,15 +17,15 @@ export enum DefaultPaths {
  */
 export interface AppConfig {
   /** Working directory for the application */
-  working_dir: string;
+  "working_dir": string;
   /** Prompt configuration settings */
-  app_prompt: {
+  "app_prompt": {
     /** Base directory for prompt files */
-    base_dir: string;
+    "base_dir": string;
   };
   /** Schema configuration settings */
-  app_schema: {
+  "app_schema": {
     /** Base directory for schema files */
-    base_dir: string;
+    "base_dir": string;
   };
 }

--- a/src/types/config_result.ts
+++ b/src/types/config_result.ts
@@ -297,22 +297,24 @@ export const Result = {
   /**
    * Converts a Promise to a ConfigResult
    */
-  async fromPromise<T>(
-    promise: Promise<T>,
-    errorMapper?: (error: unknown) => ConfigError,
-  ): Promise<ConfigResult<T, ConfigError>> {
-    try {
-      const data = await promise;
-      return Result.ok(data);
-    } catch (error) {
-      const mappedError = errorMapper ? errorMapper(error) : {
-        kind: "unknownError" as const,
-        message: error && typeof error === "object" && "message" in error
-          ? String(error.message)
-          : String(error),
-        originalError: error,
-      };
-      return Result.err(mappedError);
-    }
-  },
+  fromPromise: fromPromiseImpl,
 };
+
+async function fromPromiseImpl<T>(
+  promise: Promise<T>,
+  errorMapper?: (error: unknown) => ConfigError,
+): Promise<ConfigResult<T, ConfigError>> {
+  try {
+    const data = await promise;
+    return Result.ok(data);
+  } catch (error) {
+    const mappedError = errorMapper ? errorMapper(error) : {
+      kind: "unknownError" as const,
+      message: error && typeof error === "object" && "message" in error
+        ? String(error.message)
+        : String(error),
+      originalError: error,
+    };
+    return Result.err(mappedError);
+  }
+}

--- a/src/types/merged_config.ts
+++ b/src/types/merged_config.ts
@@ -4,7 +4,7 @@ import type { LegacyUserConfig as _LegacyUserConfig, UserConfig } from "./user_c
 // Re-export for test compatibility
 export type { AppConfig };
 export type { UserConfig };
-import { UserConfigGuards as _UserConfigGuards, UserConfigHelpers } from "./user_config.ts";
+import { type UserConfigGuards as _UserConfigGuards, UserConfigHelpers } from "./user_config.ts";
 import type { ValidPath } from "../utils/valid_path.ts";
 import { Result } from "./unified_result.ts";
 import type { UnifiedError, ValidationViolation } from "../errors/unified_errors.ts";
@@ -24,33 +24,33 @@ export interface ValidatedConfig {
   /**
    * The validated working directory for the application
    */
-  working_dir: ValidPath;
+  "working_dir": ValidPath;
 
   /**
    * Configuration settings for prompt-related functionality with validated paths
    */
-  app_prompt: {
+  "app_prompt": {
     /**
      * Validated base directory for prompt files
      */
-    base_dir: ValidPath;
+    "base_dir": ValidPath;
   };
 
   /**
    * Configuration settings for schema-related functionality with validated paths
    */
-  app_schema: {
+  "app_schema": {
     /**
      * Validated base directory for schema files
      */
-    base_dir: ValidPath;
+    "base_dir": ValidPath;
   };
 
   /**
    * Optional fields from AppConfig that may be present
    */
-  app_name?: string;
-  app_version?: string;
+  "app_name"?: string;
+  "app_version"?: string;
 
   /**
    * Additional validated custom fields
@@ -77,12 +77,12 @@ export interface AppOnlyProfile {
     userConfigExists: false;
   };
   readonly config: {
-    working_dir: string;
-    app_prompt: {
-      base_dir: string;
+    "working_dir": string;
+    "app_prompt": {
+      "base_dir": string;
     };
-    app_schema: {
-      base_dir: string;
+    "app_schema": {
+      "base_dir": string;
     };
   };
 }
@@ -100,13 +100,13 @@ export interface MergedProfile {
     userConfigExists: true;
   };
   readonly config: {
-    working_dir: string;
-    app_prompt: {
-      base_dir: string;
+    "working_dir": string;
+    "app_prompt": {
+      "base_dir": string;
       [key: string]: unknown;
     };
-    app_schema: {
-      base_dir: string;
+    "app_schema": {
+      "base_dir": string;
       [key: string]: unknown;
     };
     [key: string]: unknown; // ユーザー設定からの任意フィールド
@@ -319,12 +319,12 @@ export class ConfigProfileFactory {
   ): MergedProfile["config"] {
     // working_dirは上書き不可
     const mergedConfig: MergedProfile["config"] = {
-      working_dir: appConfig.working_dir,
-      app_prompt: {
-        base_dir: UserConfigHelpers.getPromptBaseDir(userConfig) ?? appConfig.app_prompt.base_dir,
+      "working_dir": appConfig.working_dir,
+      "app_prompt": {
+        "base_dir": UserConfigHelpers.getPromptBaseDir(userConfig) ?? appConfig.app_prompt.base_dir,
       },
-      app_schema: {
-        base_dir: UserConfigHelpers.getSchemaBaseDir(userConfig) ?? appConfig.app_schema.base_dir,
+      "app_schema": {
+        "base_dir": UserConfigHelpers.getSchemaBaseDir(userConfig) ?? appConfig.app_schema.base_dir,
       },
     };
 
@@ -417,12 +417,12 @@ export const ConfigProfileHelpers = {
  * @deprecated Use ConfigProfile instead
  */
 export interface MergedConfig extends AppConfig {
-  working_dir: string;
-  app_prompt: {
-    base_dir: string;
+  "working_dir": string;
+  "app_prompt": {
+    "base_dir": string;
   };
-  app_schema: {
-    base_dir: string;
+  "app_schema": {
+    "base_dir": string;
   };
   [key: string]: string | number | boolean | null | undefined | { [key: string]: unknown };
 }
@@ -434,12 +434,12 @@ export interface MergedConfig extends AppConfig {
 export function profileToLegacyConfig(profile: ConfigProfile): MergedConfig {
   const config = profile.config;
   const result: MergedConfig = {
-    working_dir: config.working_dir,
-    app_prompt: {
-      base_dir: config.app_prompt.base_dir,
+    "working_dir": config.working_dir,
+    "app_prompt": {
+      "base_dir": config.app_prompt.base_dir,
     },
-    app_schema: {
-      base_dir: config.app_schema.base_dir,
+    "app_schema": {
+      "base_dir": config.app_schema.base_dir,
     },
   };
 

--- a/src/types/merged_config_structure_test.ts
+++ b/src/types/merged_config_structure_test.ts
@@ -3,20 +3,23 @@
  * Level 1: Verifies configuration schema validation and profile type integrity
  */
 
-import { assertEquals, assertExists } from "@std/assert";
+import { assert, assertEquals, assertExists } from "@std/assert";
 // BreakdownLogger replaced with console for test stability
 import {
-  AppConfig,
-  AppOnlyProfile as _AppOnlyProfile,
-  ConfigProfile as _ConfigProfile,
+  type AppConfig,
+  type AppOnlyProfile as _AppOnlyProfile,
+  type ConfigProfile as _ConfigProfile,
   ConfigProfileFactory,
-  MergedConfig as _MergedConfig,
-  MergedProfile as _MergedProfile,
-  UserConfig as _UserConfig,
+  type MergedConfig as _MergedConfig,
+  type MergedProfile as _MergedProfile,
+  type UserConfig as _UserConfig,
 } from "./merged_config.ts";
 import { UserConfigFactory } from "./user_config.ts";
 
 // Logger removed for test stability
+
+const IS_NOT_IMMUTABLE = false;
+const IS_IMMUTABLE = true;
 
 Deno.test("Structure: ConfigProfile Discriminated Union Integrity", async (t) => {
   // console.log("Testing ConfigProfile discriminated union structure");
@@ -25,12 +28,12 @@ Deno.test("Structure: ConfigProfile Discriminated Union Integrity", async (t) =>
     // console.log("Verifying ConfigProfile discriminators");
 
     const mockAppConfig: AppConfig = {
-      working_dir: ".agent/climpt",
-      app_prompt: {
-        base_dir: "climpt/prompts/app",
+      "working_dir": ".agent/climpt",
+      "app_prompt": {
+        "base_dir": "climpt/prompts/app",
       },
-      app_schema: {
-        base_dir: "climpt/schema/app",
+      "app_schema": {
+        "base_dir": "climpt/schema/app",
       },
     };
 
@@ -39,7 +42,7 @@ Deno.test("Structure: ConfigProfile Discriminated Union Integrity", async (t) =>
       mockAppConfig,
       "test",
       "/test/base",
-      false,
+      IS_NOT_IMMUTABLE,
     );
     if (!appOnlyResult.success) {
       throw new Error("Failed to create AppOnlyProfile");
@@ -71,12 +74,12 @@ Deno.test("Structure: ConfigProfile Discriminated Union Integrity", async (t) =>
     // console.log("Verifying AppOnlyProfile structure");
 
     const mockAppConfig: AppConfig = {
-      working_dir: ".agent/climpt",
-      app_prompt: {
-        base_dir: "climpt/prompts/app",
+      "working_dir": ".agent/climpt",
+      "app_prompt": {
+        "base_dir": "climpt/prompts/app",
       },
-      app_schema: {
-        base_dir: "climpt/schema/app",
+      "app_schema": {
+        "base_dir": "climpt/schema/app",
       },
     };
 
@@ -84,7 +87,7 @@ Deno.test("Structure: ConfigProfile Discriminated Union Integrity", async (t) =>
       mockAppConfig,
       "test",
       "/test/app.config",
-      false,
+      IS_NOT_IMMUTABLE,
     );
 
     if (!appOnlyResult.success) {
@@ -100,7 +103,7 @@ Deno.test("Structure: ConfigProfile Discriminated Union Integrity", async (t) =>
       "/test/app.config",
       "Should have correct config path",
     );
-    assertEquals(appOnly.source.userConfigExists, false, "Should not have userConfig");
+    assert(!appOnly.source.userConfigExists, "Should not have userConfig");
 
     // console.log("AppOnlyProfile structure verified");
   });
@@ -109,12 +112,12 @@ Deno.test("Structure: ConfigProfile Discriminated Union Integrity", async (t) =>
     // console.log("Verifying MergedProfile structure");
 
     const mockAppConfig: AppConfig = {
-      working_dir: ".agent/climpt",
-      app_prompt: {
-        base_dir: "climpt/prompts/app",
+      "working_dir": ".agent/climpt",
+      "app_prompt": {
+        "base_dir": "climpt/prompts/app",
       },
-      app_schema: {
-        base_dir: "climpt/schema/app",
+      "app_schema": {
+        "base_dir": "climpt/schema/app",
       },
     };
 
@@ -145,7 +148,7 @@ Deno.test("Structure: ConfigProfile Discriminated Union Integrity", async (t) =>
       "/test/user.config",
       "Should have correct user config path",
     );
-    assertEquals(merged.source.userConfigExists, true, "Should have userConfig");
+    assert(merged.source.userConfigExists, "Should have userConfig");
 
     // console.log("MergedProfile structure verified");
   });
@@ -162,12 +165,12 @@ Deno.test("Structure: ConfigProfileFactory Contract Validation", async (t) => {
     assertExists(ConfigProfileFactory.createMerged, "createMerged should exist");
 
     const mockAppConfig: AppConfig = {
-      working_dir: ".agent/climpt",
-      app_prompt: {
-        base_dir: "climpt/prompts/app",
+      "working_dir": ".agent/climpt",
+      "app_prompt": {
+        "base_dir": "climpt/prompts/app",
       },
-      app_schema: {
-        base_dir: "climpt/schema/app",
+      "app_schema": {
+        "base_dir": "climpt/schema/app",
       },
     };
 
@@ -176,9 +179,9 @@ Deno.test("Structure: ConfigProfileFactory Contract Validation", async (t) => {
       mockAppConfig,
       "test",
       "/base/app.config",
-      false,
+      IS_NOT_IMMUTABLE,
     );
-    assertEquals(appOnlyResult.success, true, "createAppOnly should work with required parameters");
+    assert(appOnlyResult.success, "createAppOnly should work with required parameters");
 
     // Test createMerged signature
     const userConfig = UserConfigFactory.createEmpty();
@@ -189,7 +192,7 @@ Deno.test("Structure: ConfigProfileFactory Contract Validation", async (t) => {
       "/base/app.config",
       "/base/user.config",
     );
-    assertEquals(mergedResult.success, true, "createMerged should work with required parameters");
+    assert(mergedResult.success, "createMerged should work with required parameters");
 
     // console.log("Factory method signatures verified");
   });
@@ -198,12 +201,12 @@ Deno.test("Structure: ConfigProfileFactory Contract Validation", async (t) => {
     // console.log("Testing factory parameter validation");
 
     const mockAppConfig: AppConfig = {
-      working_dir: ".agent/climpt",
-      app_prompt: {
-        base_dir: "climpt/prompts/app",
+      "working_dir": ".agent/climpt",
+      "app_prompt": {
+        "base_dir": "climpt/prompts/app",
       },
-      app_schema: {
-        base_dir: "climpt/schema/app",
+      "app_schema": {
+        "base_dir": "climpt/schema/app",
       },
     };
 
@@ -212,9 +215,9 @@ Deno.test("Structure: ConfigProfileFactory Contract Validation", async (t) => {
       mockAppConfig,
       "test",
       "/valid/app.config",
-      true,
+      IS_IMMUTABLE,
     );
-    assertEquals(validAppOnlyResult.success, true, "Valid parameters should succeed");
+    assert(validAppOnlyResult.success, "Valid parameters should succeed");
     if (validAppOnlyResult.success) {
       assertEquals(
         validAppOnlyResult.data.kind,
@@ -231,7 +234,7 @@ Deno.test("Structure: ConfigProfileFactory Contract Validation", async (t) => {
       "/valid/app.config",
       "/valid/user.config",
     );
-    assertEquals(validMergedResult.success, true, "Valid parameters should succeed");
+    assert(validMergedResult.success, "Valid parameters should succeed");
     if (validMergedResult.success) {
       assertEquals(
         validMergedResult.data.kind,
@@ -247,12 +250,12 @@ Deno.test("Structure: ConfigProfileFactory Contract Validation", async (t) => {
     // console.log("Testing factory output consistency");
 
     const mockAppConfig: AppConfig = {
-      working_dir: ".agent/climpt",
-      app_prompt: {
-        base_dir: "climpt/prompts/app",
+      "working_dir": ".agent/climpt",
+      "app_prompt": {
+        "base_dir": "climpt/prompts/app",
       },
-      app_schema: {
-        base_dir: "climpt/schema/app",
+      "app_schema": {
+        "base_dir": "climpt/schema/app",
       },
     };
 
@@ -261,17 +264,17 @@ Deno.test("Structure: ConfigProfileFactory Contract Validation", async (t) => {
       mockAppConfig,
       "production",
       "/base1/app.config",
-      false,
+      IS_NOT_IMMUTABLE,
     );
     const appOnly2Result = ConfigProfileFactory.createAppOnly(
       mockAppConfig,
       "production",
       "/base2/app.config",
-      false,
+      IS_NOT_IMMUTABLE,
     );
 
-    assertEquals(appOnly1Result.success, true, "First profile creation should succeed");
-    assertEquals(appOnly2Result.success, true, "Second profile creation should succeed");
+    assert(appOnly1Result.success, "First profile creation should succeed");
+    assert(appOnly2Result.success, "Second profile creation should succeed");
 
     if (appOnly1Result.success && appOnly2Result.success) {
       const appOnly1 = appOnly1Result.data;
@@ -282,9 +285,8 @@ Deno.test("Structure: ConfigProfileFactory Contract Validation", async (t) => {
       assertEquals(appOnly1.profileName, appOnly2.profileName, "ProfileName should be consistent");
 
       // Only config paths should differ
-      assertEquals(
+      assert(
         appOnly1.source.appConfigPath !== appOnly2.source.appConfigPath,
-        true,
         "Config paths should differ when specified differently",
       );
     }
@@ -300,12 +302,12 @@ Deno.test("Structure: MergedConfig Schema Validation", async (t) => {
     // console.log("Verifying config combination logic");
 
     const mockAppConfig: AppConfig = {
-      working_dir: ".agent/climpt",
-      app_prompt: {
-        base_dir: "climpt/prompts/app",
+      "working_dir": ".agent/climpt",
+      "app_prompt": {
+        "base_dir": "climpt/prompts/app",
       },
-      app_schema: {
-        base_dir: "climpt/schema/app",
+      "app_schema": {
+        "base_dir": "climpt/schema/app",
       },
     };
 
@@ -319,7 +321,7 @@ Deno.test("Structure: MergedConfig Schema Validation", async (t) => {
       "/base/user.config",
     );
 
-    assertEquals(profileResult.success, true, "Profile creation should succeed");
+    assert(profileResult.success, "Profile creation should succeed");
 
     if (profileResult.success) {
       const profile = profileResult.data;
@@ -331,7 +333,7 @@ Deno.test("Structure: MergedConfig Schema Validation", async (t) => {
         ".agent/climpt",
         "Should preserve AppConfig working_dir",
       );
-      assertEquals(profile.source.userConfigExists, true, "Should have user config");
+      assert(profile.source.userConfigExists, "Should have user config");
     }
 
     // console.log("Config combination logic verified");
@@ -341,12 +343,12 @@ Deno.test("Structure: MergedConfig Schema Validation", async (t) => {
     // console.log("Testing directory resolution consistency");
 
     const mockAppConfig: AppConfig = {
-      working_dir: ".agent/climpt",
-      app_prompt: {
-        base_dir: "climpt/prompts/app",
+      "working_dir": ".agent/climpt",
+      "app_prompt": {
+        "base_dir": "climpt/prompts/app",
       },
-      app_schema: {
-        base_dir: "climpt/schema/app",
+      "app_schema": {
+        "base_dir": "climpt/schema/app",
       },
     };
 
@@ -354,10 +356,10 @@ Deno.test("Structure: MergedConfig Schema Validation", async (t) => {
       mockAppConfig,
       "development",
       "/override/app.config",
-      true,
+      IS_IMMUTABLE,
     );
 
-    assertEquals(profileResult.success, true, "Profile creation should succeed");
+    assert(profileResult.success, "Profile creation should succeed");
 
     if (profileResult.success) {
       const profile = profileResult.data;
@@ -387,12 +389,12 @@ Deno.test("Structure: MergedConfig Schema Validation", async (t) => {
     // console.log("Testing type safety in configuration merging");
 
     const mockAppConfig: AppConfig = {
-      working_dir: ".agent/climpt",
-      app_prompt: {
-        base_dir: "climpt/prompts/app",
+      "working_dir": ".agent/climpt",
+      "app_prompt": {
+        "base_dir": "climpt/prompts/app",
       },
-      app_schema: {
-        base_dir: "climpt/schema/app",
+      "app_schema": {
+        "base_dir": "climpt/schema/app",
       },
     };
 
@@ -435,13 +437,12 @@ Deno.test("Structure: MergedConfig Schema Validation", async (t) => {
 
     // All should be valid MergedProfiles
     for (const profileResult of profileResults) {
-      assertEquals(profileResult.success, true, "All profile creations should succeed");
+      assert(profileResult.success, "All profile creations should succeed");
       if (profileResult.success) {
         const profile = profileResult.data;
         assertEquals(profile.kind, "merged", "All merged profiles should have correct kind");
-        assertEquals(
+        assert(
           profile.source.userConfigExists,
-          true,
           "All merged profiles should have userConfig",
         );
         assertEquals(
@@ -463,12 +464,12 @@ Deno.test("Structure: Legacy Compatibility Structure", async (t) => {
     // console.log("Verifying backward compatibility");
 
     const mockAppConfig: AppConfig = {
-      working_dir: ".agent/climpt",
-      app_prompt: {
-        base_dir: "climpt/prompts/app",
+      "working_dir": ".agent/climpt",
+      "app_prompt": {
+        "base_dir": "climpt/prompts/app",
       },
-      app_schema: {
-        base_dir: "climpt/schema/app",
+      "app_schema": {
+        "base_dir": "climpt/schema/app",
       },
     };
 
@@ -476,10 +477,10 @@ Deno.test("Structure: Legacy Compatibility Structure", async (t) => {
       mockAppConfig,
       "legacy",
       "/base/app.config",
-      false,
+      IS_NOT_IMMUTABLE,
     );
 
-    assertEquals(profileResult.success, true, "Profile creation should succeed");
+    assert(profileResult.success, "Profile creation should succeed");
 
     if (profileResult.success) {
       const profile = profileResult.data;
@@ -506,12 +507,12 @@ Deno.test("Structure: Legacy Compatibility Structure", async (t) => {
     // console.log("Testing profile evolution integrity");
 
     const mockAppConfig: AppConfig = {
-      working_dir: ".agent/climpt",
-      app_prompt: {
-        base_dir: "climpt/prompts/app",
+      "working_dir": ".agent/climpt",
+      "app_prompt": {
+        "base_dir": "climpt/prompts/app",
       },
-      app_schema: {
-        base_dir: "climpt/schema/app",
+      "app_schema": {
+        "base_dir": "climpt/schema/app",
       },
     };
 
@@ -520,10 +521,10 @@ Deno.test("Structure: Legacy Compatibility Structure", async (t) => {
       mockAppConfig,
       "v1",
       "/current/app.config",
-      true,
+      IS_IMMUTABLE,
     );
 
-    assertEquals(profileResult.success, true, "Profile creation should succeed");
+    assert(profileResult.success, "Profile creation should succeed");
 
     if (profileResult.success) {
       const profile = profileResult.data;

--- a/src/types/unified_result.ts
+++ b/src/types/unified_result.ts
@@ -3,7 +3,7 @@
  * This replaces ConfigResult to provide a single Result type for the entire application
  */
 
-import { UnifiedError } from "../errors/unified_errors.ts";
+import type { UnifiedError } from "../errors/unified_errors.ts";
 
 /**
  * Success case of Result type
@@ -253,30 +253,32 @@ export const Result: {
   /**
    * Converts a Promise to a Result, catching thrown errors
    */
-  async fromPromise<T>(
-    promise: Promise<T>,
-    errorMapper?: (error: unknown) => UnifiedError,
-  ): Promise<Result<T, UnifiedError>> {
-    try {
-      const value = await promise;
-      return Result.ok(value);
-    } catch (error) {
-      if (errorMapper) {
-        return Result.err(errorMapper(error));
-      }
-      // Default error mapping
-      const errorMessage = error && typeof error === "object" && "message" in error
-        ? String(error.message)
-        : String(error);
-      return Result.err({
-        kind: "UNKNOWN_ERROR",
-        originalError: error,
-        message: errorMessage,
-        timestamp: new Date(),
-        stackTrace: error && typeof error === "object" && "stack" in error
-          ? String(error.stack)
-          : undefined,
-      } as UnifiedError);
-    }
-  },
+  fromPromise: fromPromiseImpl,
 };
+
+async function fromPromiseImpl<T>(
+  promise: Promise<T>,
+  errorMapper?: (error: unknown) => UnifiedError,
+): Promise<Result<T, UnifiedError>> {
+  try {
+    const value = await promise;
+    return Result.ok(value);
+  } catch (error) {
+    if (errorMapper) {
+      return Result.err(errorMapper(error));
+    }
+    // Default error mapping
+    const errorMessage = error && typeof error === "object" && "message" in error
+      ? String(error.message)
+      : String(error);
+    return Result.err({
+      kind: "UNKNOWN_ERROR",
+      originalError: error,
+      message: errorMessage,
+      timestamp: new Date(),
+      stackTrace: error && typeof error === "object" && "stack" in error
+        ? String(error.stack)
+        : undefined,
+    } as UnifiedError);
+  }
+}

--- a/src/types/user_config.ts
+++ b/src/types/user_config.ts
@@ -25,8 +25,8 @@ export interface EmptyUserConfig extends BaseUserConfig {
  */
 export interface PromptOnlyUserConfig extends BaseUserConfig {
   readonly kind: "prompt-only";
-  readonly app_prompt: {
-    readonly base_dir: string;
+  readonly "app_prompt": {
+    readonly "base_dir": string;
     readonly [key: string]: unknown;
   };
 }
@@ -36,8 +36,8 @@ export interface PromptOnlyUserConfig extends BaseUserConfig {
  */
 export interface SchemaOnlyUserConfig extends BaseUserConfig {
   readonly kind: "schema-only";
-  readonly app_schema: {
-    readonly base_dir: string;
+  readonly "app_schema": {
+    readonly "base_dir": string;
     readonly [key: string]: unknown;
   };
 }
@@ -47,12 +47,12 @@ export interface SchemaOnlyUserConfig extends BaseUserConfig {
  */
 export interface CompleteUserConfig extends BaseUserConfig {
   readonly kind: "complete";
-  readonly app_prompt: {
-    readonly base_dir: string;
+  readonly "app_prompt": {
+    readonly "base_dir": string;
     readonly [key: string]: unknown;
   };
-  readonly app_schema: {
-    readonly base_dir: string;
+  readonly "app_schema": {
+    readonly "base_dir": string;
     readonly [key: string]: unknown;
   };
 }
@@ -73,14 +73,14 @@ export type UserConfig =
  */
 export interface LegacyUserConfig {
   /** Optional prompt configuration overrides */
-  app_prompt?: {
+  "app_prompt"?: {
     /** Base directory for prompt files */
-    base_dir: string;
+    "base_dir": string;
   };
   /** Optional schema configuration overrides */
-  app_schema?: {
+  "app_schema"?: {
     /** Base directory for schema files */
-    base_dir: string;
+    "base_dir": string;
   };
   /** Additional custom configuration fields */
   [key: string]:

--- a/src/types/user_config_structure_test.ts
+++ b/src/types/user_config_structure_test.ts
@@ -3,18 +3,18 @@
  * Level 1: Verifies type definition integrity and union variant completeness
  */
 
-import { assertEquals, assertExists } from "@std/assert";
+import { assert, assertEquals, assertExists } from "@std/assert";
 // BreakdownLogger replaced with console for test stability
 import {
-  CompleteUserConfig as _CompleteUserConfig,
-  EmptyUserConfig as _EmptyUserConfig,
-  LegacyUserConfig,
-  PromptOnlyUserConfig as _PromptOnlyUserConfig,
-  SchemaOnlyUserConfig as _SchemaOnlyUserConfig,
-  UserConfig,
+  type CompleteUserConfig as _CompleteUserConfig,
+  type EmptyUserConfig as _EmptyUserConfig,
+  type LegacyUserConfig,
+  type PromptOnlyUserConfig as _PromptOnlyUserConfig,
+  type SchemaOnlyUserConfig as _SchemaOnlyUserConfig,
+  type UserConfig,
   UserConfigFactory,
   UserConfigGuards,
-  UserConfigHelpers as _UserConfigHelpers,
+  type UserConfigHelpers as _UserConfigHelpers,
 } from "./user_config.ts";
 
 // Logger removed for test stability
@@ -214,9 +214,8 @@ Deno.test("Structure: UserConfigFactory Contract Validation", async (t) => {
 
       // Should match expected kind values
       const validKinds = ["empty", "prompt-only", "schema-only", "complete"];
-      assertEquals(
+      assert(
         validKinds.includes(variant.kind),
-        true,
         `Kind "${variant.kind}" should be valid`,
       );
     }
@@ -237,46 +236,39 @@ Deno.test("Structure: UserConfigGuards Type Safety", async (t) => {
     const complete = UserConfigFactory.createComplete("/test/prompt", "/test/schema");
 
     // Test isEmpty
-    assertEquals(UserConfigGuards.isEmpty(empty), true, "isEmpty should identify empty config");
-    assertEquals(
-      UserConfigGuards.isEmpty(promptOnly),
-      false,
+    assert(UserConfigGuards.isEmpty(empty), "isEmpty should identify empty config");
+    assert(
+      !UserConfigGuards.isEmpty(promptOnly),
       "isEmpty should reject non-empty config",
     );
 
     // Test isPromptOnly
-    assertEquals(
+    assert(
       UserConfigGuards.isPromptOnly(promptOnly),
-      true,
       "isPromptOnly should identify prompt-only config",
     );
-    assertEquals(
-      UserConfigGuards.isPromptOnly(empty),
-      false,
+    assert(
+      !UserConfigGuards.isPromptOnly(empty),
       "isPromptOnly should reject non-prompt-only config",
     );
 
     // Test isSchemaOnly
-    assertEquals(
+    assert(
       UserConfigGuards.isSchemaOnly(schemaOnly),
-      true,
       "isSchemaOnly should identify schema-only config",
     );
-    assertEquals(
-      UserConfigGuards.isSchemaOnly(complete),
-      false,
+    assert(
+      !UserConfigGuards.isSchemaOnly(complete),
       "isSchemaOnly should reject non-schema-only config",
     );
 
     // Test isComplete
-    assertEquals(
+    assert(
       UserConfigGuards.isComplete(complete),
-      true,
       "isComplete should identify complete config",
     );
-    assertEquals(
-      UserConfigGuards.isComplete(schemaOnly),
-      false,
+    assert(
+      !UserConfigGuards.isComplete(schemaOnly),
       "isComplete should reject non-complete config",
     );
 

--- a/src/types/valid_profile_prefix.ts
+++ b/src/types/valid_profile_prefix.ts
@@ -1,5 +1,5 @@
 import { Result } from "./unified_result.ts";
-import { ErrorFactories, UnifiedError } from "../errors/unified_errors.ts";
+import { ErrorFactories, type UnifiedError } from "../errors/unified_errors.ts";
 
 /**
  * ValidProfilePrefix Smart Constructor

--- a/src/utils/config_cache.ts
+++ b/src/utils/config_cache.ts
@@ -1,5 +1,5 @@
 import { Result } from "../types/unified_result.ts";
-import { UnifiedError } from "../errors/unified_errors.ts";
+import type { UnifiedError } from "../errors/unified_errors.ts";
 import type { MergedConfig } from "../types/merged_config.ts";
 
 /**

--- a/src/utils/error_cache.ts
+++ b/src/utils/error_cache.ts
@@ -1,5 +1,5 @@
-import { ErrorFactories, UnifiedError } from "../errors/unified_errors.ts";
-import { PathErrorReason } from "../errors/unified_errors.ts";
+import { ErrorFactories, type UnifiedError } from "../errors/unified_errors.ts";
+import type { PathErrorReason } from "../errors/unified_errors.ts";
 
 /**
  * Error instance cache to reduce error creation overhead

--- a/src/utils/valid_path.ts
+++ b/src/utils/valid_path.ts
@@ -1,12 +1,12 @@
 import {
-  ConfigResult,
-  PathError,
-  PathErrorReason as _PathErrorReason,
+  type ConfigResult,
+  type PathError,
+  type PathErrorReason as _PathErrorReason,
   Result,
-  ValidationError as _ValidationError,
+  type ValidationError as _ValidationError,
 } from "../types/config_result.ts";
 import { Result as UnifiedResult } from "../types/unified_result.ts";
-import { ErrorFactories, UnifiedError } from "../errors/unified_errors.ts";
+import { ErrorFactories, type UnifiedError } from "../errors/unified_errors.ts";
 
 /**
  * ValidPath - A Smart Constructor pattern implementation for safe path handling

--- a/src/validators/config_validator.ts
+++ b/src/validators/config_validator.ts
@@ -1,7 +1,7 @@
 import type { AppConfig } from "../types/app_config.ts";
 import type { UserConfig } from "../types/user_config.ts";
 import { hasPromptConfig, hasSchemaConfig } from "../types/user_config.ts";
-import { ConfigResult, Result, ValidationError } from "../types/config_result.ts";
+import { type ConfigResult, Result, type ValidationError } from "../types/config_result.ts";
 
 export class ConfigValidator {
   static validateAppConfig(config: unknown): ConfigResult<AppConfig, ValidationError[]> {

--- a/src/validators/path_validator.ts
+++ b/src/validators/path_validator.ts
@@ -1,6 +1,11 @@
 import { isAbsolute, join, normalize } from "https://deno.land/std@0.224.0/path/mod.ts";
 import { exists } from "https://deno.land/std@0.224.0/fs/exists.ts";
-import { ConfigResult, PathError, Result, UnknownError } from "../types/config_result.ts";
+import {
+  type ConfigResult,
+  type PathError,
+  Result,
+  type UnknownError,
+} from "../types/config_result.ts";
 import { ValidPath } from "../utils/valid_path.ts";
 
 /**

--- a/src/validators/schema_validator.ts
+++ b/src/validators/schema_validator.ts
@@ -1,4 +1,7 @@
-import { ConfigResult, Result, ValidationError } from "../types/config_result.ts";
+import { type ConfigResult, Result, type ValidationError } from "../types/config_result.ts";
+
+/** Constant representing a successful validation result */
+const VALIDATION_SUCCESS = true as const;
 
 /**
  * Schema definition for validating configuration objects
@@ -102,7 +105,7 @@ export class SchemaValidator {
       }
     }
 
-    return Result.ok(true);
+    return Result.ok(VALIDATION_SUCCESS);
   }
 
   /**
@@ -137,7 +140,7 @@ export class SchemaValidator {
       });
     }
 
-    return Result.ok(true);
+    return Result.ok(VALIDATION_SUCCESS);
   }
 
   /**
@@ -251,6 +254,6 @@ export class SchemaValidator {
         message: `Field '${fieldName}' must be a non-empty string`,
       });
     }
-    return Result.ok(true);
+    return Result.ok(VALIDATION_SUCCESS);
   }
 }

--- a/tests/3.integrated/breakdown_config_integration_test.ts
+++ b/tests/3.integrated/breakdown_config_integration_test.ts
@@ -3,10 +3,10 @@
  * Level 3: Verifies complete integration flows with Total Function design
  */
 
-import { assertEquals, assertExists, assertRejects, assertThrows } from "@std/assert";
+import { assert, assertEquals, assertExists, assertRejects, assertThrows } from "@std/assert";
 import { BreakdownConfig } from "../../mod.ts";
-import { Result as _Result } from "../../src/types/unified_result.ts";
-import { UnifiedError as _UnifiedError } from "../../src/errors/unified_errors.ts";
+import type { Result as _Result } from "../../src/types/unified_result.ts";
+import type { UnifiedError as _UnifiedError } from "../../src/errors/unified_errors.ts";
 import {
   cleanupTestConfigs,
   setupAppConfigOnly,
@@ -15,27 +15,28 @@ import {
 } from "../test_utils.ts";
 
 Deno.test("Integration: BreakdownConfig Total Function Complete Flow", async (t) => {
+  // deno-lint-ignore no-console
   console.log("Testing BreakdownConfig complete integration flow with Total Function principles");
 
   await t.step("Smart Constructor integration with valid inputs", () => {
     // Test 1: Default parameters
     const defaultResult = BreakdownConfig.create();
-    assertEquals(defaultResult.success, true, "Default parameters should succeed");
+    assert(defaultResult.success, "Default parameters should succeed");
     if (defaultResult.success) {
       assertExists(defaultResult.data);
-      assertEquals(defaultResult.data instanceof BreakdownConfig, true);
+      assert(defaultResult.data instanceof BreakdownConfig);
     }
 
     // Test 2: With valid profile
     const profileResult = BreakdownConfig.create("production");
-    assertEquals(profileResult.success, true, "Valid profile should succeed");
+    assert(profileResult.success, "Valid profile should succeed");
     if (profileResult.success) {
       assertExists(profileResult.data);
     }
 
     // Test 3: With valid profile and baseDir
     const bothResult = BreakdownConfig.create("staging", "/tmp/test");
-    assertEquals(bothResult.success, true, "Valid parameters should succeed");
+    assert(bothResult.success, "Valid parameters should succeed");
   });
 
   await t.step("Smart Constructor integration with invalid inputs", () => {
@@ -49,7 +50,7 @@ Deno.test("Integration: BreakdownConfig Total Function Complete Flow", async (t)
 
     for (const profile of invalidProfiles) {
       const result = BreakdownConfig.create(profile);
-      assertEquals(result.success, false, `Profile "${profile}" should fail`);
+      assert(!result.success, `Profile "${profile}" should fail`);
       if (!result.success) {
         assertEquals(result.error.kind, "CONFIG_VALIDATION_ERROR");
       }
@@ -69,12 +70,12 @@ Deno.test("Integration: Safe Method APIs with Result Pattern", async (t) => {
       const config = configResult.data;
       const loadResult = await config.loadConfigSafe();
 
-      assertEquals(loadResult.success, true, "loadConfigSafe should succeed");
+      assert(loadResult.success, "loadConfigSafe should succeed");
       // loadConfigSafe returns void, not the config data
       // We need to call getConfigSafe to get the actual config
       if (loadResult.success) {
         const configResult = await config.getConfigSafe();
-        assertEquals(configResult.success, true);
+        assert(configResult.success);
         if (configResult.success) {
           assertExists(configResult.data.working_dir);
           assertExists(configResult.data.app_prompt);
@@ -95,7 +96,7 @@ Deno.test("Integration: Safe Method APIs with Result Pattern", async (t) => {
     const config = configResult.data;
     const loadResult = await config.loadConfigSafe();
 
-    assertEquals(loadResult.success, false, "loadConfigSafe should fail gracefully");
+    assert(!loadResult.success, "loadConfigSafe should fail gracefully");
     if (!loadResult.success) {
       assertEquals(loadResult.error.kind, "CONFIG_FILE_NOT_FOUND");
     }
@@ -110,7 +111,7 @@ Deno.test("Integration: Safe Method APIs with Result Pattern", async (t) => {
     const config = configResult.data;
     const getResult = await config.getConfigSafe();
 
-    assertEquals(getResult.success, false, "getConfigSafe should fail before loading");
+    assert(!getResult.success, "getConfigSafe should fail before loading");
     if (!getResult.success) {
       assertEquals(getResult.error.kind, "CONFIG_NOT_LOADED");
     }
@@ -128,7 +129,7 @@ Deno.test("Integration: Safe Method APIs with Result Pattern", async (t) => {
 
       // Before loading
       const beforeResult = await config.getWorkingDirSafe();
-      assertEquals(beforeResult.success, false);
+      assert(!beforeResult.success);
       if (!beforeResult.success) {
         assertEquals(beforeResult.error.kind, "CONFIG_NOT_LOADED");
       }
@@ -136,7 +137,7 @@ Deno.test("Integration: Safe Method APIs with Result Pattern", async (t) => {
       // After loading
       await config.loadConfig();
       const afterResult = await config.getWorkingDirSafe();
-      assertEquals(afterResult.success, true);
+      assert(afterResult.success);
       if (afterResult.success) {
         assertExists(afterResult.data);
       }
@@ -171,7 +172,7 @@ app_schema:
 
       // Safe method should handle gracefully
       const loadResult = await config.loadConfigSafe();
-      assertEquals(loadResult.success, false);
+      assert(!loadResult.success);
       if (!loadResult.success) {
         assertEquals(loadResult.error.kind, "CONFIG_PARSE_ERROR");
       }
@@ -188,12 +189,12 @@ app_schema:
 
   await t.step("Complete error flow with validation failures", async () => {
     const invalidConfig = {
-      working_dir: "", // Empty working_dir
-      app_prompt: {
-        base_dir: "../../../escape", // Path traversal attempt
+      "working_dir": "", // Empty working_dir
+      "app_prompt": {
+        "base_dir": "../../../escape", // Path traversal attempt
       },
-      app_schema: {
-        base_dir: "/absolute/path", // Absolute path where relative expected
+      "app_schema": {
+        "base_dir": "/absolute/path", // Absolute path where relative expected
       },
     };
 
@@ -207,7 +208,7 @@ app_schema:
       const config = configResult.data;
       const loadResult = await config.loadConfigSafe();
 
-      assertEquals(loadResult.success, false);
+      assert(!loadResult.success);
       if (!loadResult.success) {
         // Should be validation error
         assertExists(loadResult.error.kind);
@@ -224,7 +225,7 @@ Deno.test("Integration: Complete Configuration Lifecycle", async (t) => {
     try {
       // Step 1: Create configuration
       const createResult = BreakdownConfig.create(undefined, tempDir);
-      assertEquals(createResult.success, true);
+      assert(createResult.success);
       if (!createResult.success) {
         throw new Error("Create failed");
       }
@@ -233,14 +234,14 @@ Deno.test("Integration: Complete Configuration Lifecycle", async (t) => {
 
       // Step 2: Load configuration
       const loadResult = await config.loadConfigSafe();
-      assertEquals(loadResult.success, true);
+      assert(loadResult.success);
       if (!loadResult.success) {
         throw new Error("Load failed");
       }
 
       // Step 3: Access configuration
       const configResult = await config.getConfigSafe();
-      assertEquals(configResult.success, true);
+      assert(configResult.success);
       if (configResult.success) {
         assertExists(configResult.data.working_dir);
         assertExists(configResult.data.app_prompt);
@@ -249,13 +250,13 @@ Deno.test("Integration: Complete Configuration Lifecycle", async (t) => {
 
       // Step 4: Get derived paths
       const workingDirResult = await config.getWorkingDirSafe();
-      assertEquals(workingDirResult.success, true);
+      assert(workingDirResult.success);
 
       const promptDirResult = await config.getPromptDirSafe();
-      assertEquals(promptDirResult.success, true);
+      assert(promptDirResult.success);
 
       const schemaDirResult = await config.getSchemaDirSafe();
-      assertEquals(schemaDirResult.success, true);
+      assert(schemaDirResult.success);
 
       // Verify all paths exist
       if (workingDirResult.success && promptDirResult.success && schemaDirResult.success) {
@@ -272,16 +273,18 @@ Deno.test("Integration: Complete Configuration Lifecycle", async (t) => {
     const profiles = ["development", "staging", "production"];
 
     for (const profile of profiles) {
+      // deno-lint-ignore no-await-in-loop
       const tempDir = await setupAppConfigOnly();
       try {
         // Create profile-specific config
         const createResult = BreakdownConfig.create(profile, tempDir);
-        assertEquals(createResult.success, true);
+        assert(createResult.success);
 
         if (createResult.success) {
           const config = createResult.data;
 
           // Each profile should work independently
+          // deno-lint-ignore no-await-in-loop
           const loadResult = await config.loadConfigSafe();
 
           // loadConfigSafe might fail if profile config doesn't exist
@@ -295,6 +298,7 @@ Deno.test("Integration: Complete Configuration Lifecycle", async (t) => {
           }
         }
       } finally {
+        // deno-lint-ignore no-await-in-loop
         await cleanupTestConfigs(tempDir);
       }
     }
@@ -348,7 +352,7 @@ Deno.test("Integration: Result Type Chaining and Composition", async (t) => {
         return { success: true as const, data: transformedData };
       })();
 
-      assertEquals(finalResult.success, true);
+      assert(finalResult.success);
       if (finalResult.success) {
         assertExists(finalResult.data.paths);
         assertExists(finalResult.data.hasFiles);
@@ -366,7 +370,7 @@ Deno.test("Integration: Legacy API Compatibility", async (t) => {
       // Legacy pattern that throws
       const config = BreakdownConfig.createLegacy(undefined, tempDir);
       assertExists(config);
-      assertEquals(config instanceof BreakdownConfig, true);
+      assert(config instanceof BreakdownConfig);
 
       // Should be able to use normally
       await config.loadConfig();
@@ -386,4 +390,5 @@ Deno.test("Integration: Legacy API Compatibility", async (t) => {
   });
 });
 
+// deno-lint-ignore no-console
 console.log("BreakdownConfig integration tests complete - Total Function principles verified");

--- a/tests/3.integrated/config_loading_integration_test.ts
+++ b/tests/3.integrated/config_loading_integration_test.ts
@@ -8,7 +8,7 @@
  * - Total Function原則の遵守
  */
 
-import { assertEquals, assertExists } from "https://deno.land/std@0.219.0/assert/mod.ts";
+import { assert, assertEquals, assertExists } from "https://deno.land/std@0.219.0/assert/mod.ts";
 import { afterEach, beforeEach, describe, it } from "https://deno.land/std@0.219.0/testing/bdd.ts";
 import { join } from "https://deno.land/std@0.219.0/path/mod.ts";
 import { stringify as stringifyYaml } from "https://deno.land/std@0.219.0/yaml/mod.ts";
@@ -40,19 +40,19 @@ describe("Config Loading Integration Tests", () => {
   describe("アプリ設定 + ユーザー設定の統合検証", () => {
     it("デフォルトプロファイルでのアプリ設定とユーザー設定のマージ", async () => {
       const configResult = BreakdownConfig.create(undefined, tempDir);
-      assertEquals(configResult.success, true);
+      assert(configResult.success);
       if (!configResult.success) return;
       const config = configResult.data;
 
       const loadResult = await config.loadConfigSafe();
 
       assertExists(loadResult);
-      assertEquals(loadResult.success, true);
+      assert(loadResult.success);
 
       // 設定が正常にロードされたら、個別に値を取得
       if (loadResult.success) {
         const configDataResult = await config.getConfigSafe();
-        assertEquals(configDataResult.success, true);
+        assert(configDataResult.success);
 
         if (configDataResult.success) {
           // アプリ設定の確認
@@ -77,18 +77,18 @@ describe("Config Loading Integration Tests", () => {
       await Deno.remove(userConfigPath);
 
       const configResult = BreakdownConfig.create(undefined, tempDir);
-      assertEquals(configResult.success, true);
+      assert(configResult.success);
       if (!configResult.success) return;
       const config = configResult.data;
 
       const loadResult = await config.loadConfigSafe();
 
       assertExists(loadResult);
-      assertEquals(loadResult.success, true);
+      assert(loadResult.success);
 
       if (loadResult.success) {
         const configDataResult = await config.getConfigSafe();
-        assertEquals(configDataResult.success, true);
+        assert(configDataResult.success);
 
         if (configDataResult.success) {
           // アプリ設定のデフォルト値が使用されることを確認
@@ -108,16 +108,16 @@ describe("Config Loading Integration Tests", () => {
     it("アプリ設定とユーザー設定の深いマージ検証", async () => {
       // より複雑な設定を作成
       const complexAppConfig = {
-        working_dir: ".agent/climpt",
-        app_prompt: {
-          base_dir: "prompts/default",
+        "working_dir": ".agent/climpt",
+        "app_prompt": {
+          "base_dir": "prompts/default",
           templates: {
             main: "main.txt",
             sub: "sub.txt",
           },
         },
-        app_schema: {
-          base_dir: "schemas/default",
+        "app_schema": {
+          "base_dir": "schemas/default",
           version: "1.0.0",
         },
         features: {
@@ -127,8 +127,8 @@ describe("Config Loading Integration Tests", () => {
       };
 
       const complexUserConfig = {
-        app_prompt: {
-          base_dir: "custom/prompts", // base_dirを追加
+        "app_prompt": {
+          "base_dir": "custom/prompts", // base_dirを追加
           templates: {
             main: "custom-main.txt", // 上書き
             extra: "extra.txt", // 追加
@@ -152,18 +152,18 @@ describe("Config Loading Integration Tests", () => {
       );
 
       const configResult = BreakdownConfig.create(undefined, tempDir);
-      assertEquals(configResult.success, true);
+      assert(configResult.success);
       if (!configResult.success) return;
       const config = configResult.data;
 
       const loadResult = await config.loadConfigSafe();
 
       assertExists(loadResult);
-      assertEquals(loadResult.success, true);
+      assert(loadResult.success);
 
       if (loadResult.success) {
         const configDataResult = await config.getConfigSafe();
-        assertEquals(configDataResult.success, true);
+        assert(configDataResult.success);
 
         if (configDataResult.success) {
           const mergedConfig = configDataResult.data;
@@ -187,9 +187,9 @@ describe("Config Loading Integration Tests", () => {
           // featuresプロパティに安全にアクセス
           const features = configRecord.features as Record<string, unknown> | undefined;
           if (features && typeof features === "object") {
-            assertEquals(features.cache, true);
-            assertEquals(features.logging, true);
-            assertEquals(features.debug, true);
+            assert(features.cache);
+            assert(features.logging);
+            assert(features.debug);
           }
         }
       }
@@ -202,14 +202,14 @@ describe("Config Loading Integration Tests", () => {
       tempDir = await setupCustomConfigSet("production");
 
       const configResult = BreakdownConfig.create("production", tempDir);
-      assertEquals(configResult.success, true);
+      assert(configResult.success);
       if (!configResult.success) return;
       const config = configResult.data;
 
       const loadResult = await config.loadConfigSafe();
 
       assertExists(loadResult);
-      assertEquals(loadResult.success, true);
+      assert(loadResult.success);
       if (loadResult.success) {
         // プロファイル固有の設定が読み込まれることを確認
         const configDataResult = await config.getConfigSafe();
@@ -225,20 +225,24 @@ describe("Config Loading Integration Tests", () => {
       const profiles = ["development", "staging", "production"];
 
       for (const profile of profiles) {
+        // deno-lint-ignore no-await-in-loop
         await cleanupTestConfigs(tempDir);
+        // deno-lint-ignore no-await-in-loop
         tempDir = await setupCustomConfigSet(profile);
 
         const configResult = BreakdownConfig.create(profile, tempDir);
-        assertEquals(configResult.success, true);
+        assert(configResult.success);
         if (!configResult.success) continue;
         const config = configResult.data;
 
+        // deno-lint-ignore no-await-in-loop
         const loadResult = await config.loadConfigSafe();
 
         assertExists(loadResult);
-        assertEquals(loadResult.success, true);
+        assert(loadResult.success);
         if (loadResult.success) {
           // プロファイル固有のパスが正しく設定されていることを確認
+          // deno-lint-ignore no-await-in-loop
           const configDataResult = await config.getConfigSafe();
           if (configDataResult.success) {
             const mergedConfig = configDataResult.data;
@@ -268,18 +272,17 @@ describe("Config Loading Integration Tests", () => {
       for (const invalidProfile of invalidProfiles) {
         const configResult = BreakdownConfig.create(invalidProfile, tempDir);
 
-        assertEquals(configResult.success, false);
+        assert(!configResult.success);
         if (!configResult.success) {
           assertEquals(configResult.error.kind, "CONFIG_VALIDATION_ERROR");
           const errorMessage = configResult.error instanceof Error
             ? configResult.error.message
             : String(configResult.error.message || configResult.error);
           assertExists(errorMessage);
-          assertEquals(
+          assert(
             errorMessage.includes(
               "only alphanumeric characters and hyphens are allowed",
             ),
-            true,
           );
         }
       }
@@ -287,14 +290,14 @@ describe("Config Loading Integration Tests", () => {
 
     it("存在しないプロファイルファイルでのフォールバック動作", async () => {
       const configResult = BreakdownConfig.create("non-existent-profile", tempDir);
-      assertEquals(configResult.success, true);
+      assert(configResult.success);
       if (!configResult.success) return;
       const config = configResult.data;
 
       const loadResult = await config.loadConfigSafe();
 
       // プロファイルファイルが存在しない場合はエラーになる
-      assertEquals(loadResult.success, false);
+      assert(!loadResult.success);
       if (!loadResult.success) {
         assertEquals(loadResult.error.kind, "CONFIG_FILE_NOT_FOUND");
         const errorMessage = loadResult.error instanceof Error
@@ -317,13 +320,13 @@ describe("Config Loading Integration Tests", () => {
       );
 
       const configResult = BreakdownConfig.create(undefined, tempDir);
-      assertEquals(configResult.success, true);
+      assert(configResult.success);
       if (!configResult.success) return;
       const config = configResult.data;
 
       const loadResult = await config.loadConfigSafe();
 
-      assertEquals(loadResult.success, false);
+      assert(!loadResult.success);
       if (!loadResult.success) {
         assertEquals(loadResult.error.kind, "CONFIG_PARSE_ERROR");
         const errorMessage = loadResult.error instanceof Error
@@ -339,23 +342,23 @@ describe("Config Loading Integration Tests", () => {
         join(configDir, "app.yml"),
         stringifyYaml({
           // working_dirが欠落
-          app_prompt: {
-            base_dir: "prompts",
+          "app_prompt": {
+            "base_dir": "prompts",
           },
-          app_schema: {
-            base_dir: "schemas",
+          "app_schema": {
+            "base_dir": "schemas",
           },
         }),
       );
 
       const configResult = BreakdownConfig.create(undefined, tempDir);
-      assertEquals(configResult.success, true);
+      assert(configResult.success);
       if (!configResult.success) return;
       const config = configResult.data;
 
       const loadResult = await config.loadConfigSafe();
 
-      assertEquals(loadResult.success, false);
+      assert(!loadResult.success);
       if (!loadResult.success) {
         assertEquals(loadResult.error.kind, "CONFIG_VALIDATION_ERROR");
         const errorMessage = loadResult.error instanceof Error
@@ -363,26 +366,25 @@ describe("Config Loading Integration Tests", () => {
           : String(loadResult.error.message || loadResult.error);
         assertExists(errorMessage);
         // エラーメッセージにworking_dirが含まれることを確認
-        assertEquals(errorMessage.includes("working_dir"), true);
+        assert(errorMessage.includes("working_dir"));
       }
     });
 
     it("ファイルアクセスエラーのResult型ハンドリング", async () => {
       // 存在しないディレクトリを指定
       const configResult = BreakdownConfig.create(undefined, "/nonexistent/directory/path");
-      assertEquals(configResult.success, true);
+      assert(configResult.success);
       if (!configResult.success) return;
       const config = configResult.data;
 
       const loadResult = await config.loadConfigSafe();
 
-      assertEquals(loadResult.success, false);
+      assert(!loadResult.success);
       if (!loadResult.success) {
         // ファイルアクセスエラーまたはファイル未検出エラー
-        assertEquals(
+        assert(
           loadResult.error.kind === "CONFIG_FILE_NOT_FOUND" ||
             loadResult.error.kind === "FILE_SYSTEM_ERROR",
-          true,
         );
       }
     });
@@ -394,24 +396,24 @@ describe("Config Loading Integration Tests", () => {
       await Deno.writeTextFile(
         join(configDir, "app.yml"),
         stringifyYaml({
-          working_dir: "", // 空文字列
-          app_prompt: {
-            base_dir: "../../../etc", // パストラバーサル
+          "working_dir": "", // 空文字列
+          "app_prompt": {
+            "base_dir": "../../../etc", // パストラバーサル
           },
-          app_schema: {
-            base_dir: 123, // 型エラー
+          "app_schema": {
+            "base_dir": 123, // 型エラー
           },
         }),
       );
 
       const configResult = BreakdownConfig.create(undefined, tempDir);
-      assertEquals(configResult.success, true);
+      assert(configResult.success);
       if (!configResult.success) return;
       const config = configResult.data;
 
       const loadResult = await config.loadConfigSafe();
 
-      assertEquals(loadResult.success, false);
+      assert(!loadResult.success);
       if (!loadResult.success) {
         // 複数のエラーが発生する可能性があるが、最初のエラーが返される
         assertExists(loadResult.error.kind);
@@ -424,7 +426,7 @@ describe("Config Loading Integration Tests", () => {
 
     it("Result型チェーンでの安全な操作", async () => {
       const configResult = BreakdownConfig.create(undefined, tempDir);
-      assertEquals(configResult.success, true);
+      assert(configResult.success);
       if (!configResult.success) return;
       const config = configResult.data;
 
@@ -444,9 +446,9 @@ describe("Config Loading Integration Tests", () => {
       // 設定がロードされた場合は、個別の値を取得可能
       if (Result.isOk(loadResult)) {
         const workingDirResult = await config.getWorkingDirSafe();
-        assertEquals(Result.isOk(workingDirResult), true);
+        assert(Result.isOk(workingDirResult));
         if (Result.isOk(workingDirResult)) {
-          assertEquals(workingDirResult.data.endsWith(validAppConfig.working_dir), true);
+          assert(workingDirResult.data.endsWith(validAppConfig.working_dir));
         }
       }
     });
@@ -477,6 +479,7 @@ describe("Config Loading Integration Tests", () => {
         // 成功または失敗のいずれか
         if (configResult.success) {
           assertExists(configResult.data);
+          // deno-lint-ignore no-await-in-loop
           const loadResult = await configResult.data.loadConfigSafe();
 
           // loadも必ずResultを返す
@@ -485,6 +488,7 @@ describe("Config Loading Integration Tests", () => {
 
           if (loadResult.success) {
             // ロード成功時は設定データにアクセス可能
+            // deno-lint-ignore no-await-in-loop
             const configDataResult = await configResult.data.getConfigSafe();
             assertExists(configDataResult.success);
           } else {

--- a/tests/3.integrated/error_handling_integration_test.ts
+++ b/tests/3.integrated/error_handling_integration_test.ts
@@ -13,7 +13,7 @@ import { assert, assertEquals, assertExists, assertRejects } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
 import { BreakdownConfig } from "../../mod.ts";
 import { Result } from "../../src/types/unified_result.ts";
-import { ErrorFactories, UnifiedError } from "../../src/errors/unified_errors.ts";
+import { ErrorFactories, type UnifiedError } from "../../src/errors/unified_errors.ts";
 import { cleanupTestConfigs, setupInvalidConfig, setupMergeConfigs } from "../test_utils.ts";
 import {
   assertResultError,
@@ -128,9 +128,9 @@ describe("Total Function Error Handling Integration", () => {
   describe("UnifiedError Type Consistency", () => {
     it("should maintain error type discrimination across operations", async () => {
       const tempDir = await setupInvalidConfig({
-        working_dir: "",
-        app_prompt: { base_dir: "../../../etc" },
-        app_schema: { base_dir: "a".repeat(300) },
+        "working_dir": "",
+        "app_prompt": { "base_dir": "../../../etc" },
+        "app_schema": { "base_dir": "a".repeat(300) },
       });
 
       try {
@@ -230,14 +230,17 @@ describe("Total Function Error Handling Integration", () => {
           const config = configResult.data;
 
           // Safe operations should never throw
+          // deno-lint-ignore no-await-in-loop
           const loadResult = await config.loadConfigSafe();
           assertExists(loadResult);
           assertExists(loadResult.success);
 
+          // deno-lint-ignore no-await-in-loop
           const getConfigResult = await config.getConfigSafe();
           assertExists(getConfigResult);
           assertExists(getConfigResult.success);
 
+          // deno-lint-ignore no-await-in-loop
           const workingDirResult = await config.getWorkingDirSafe();
           assertExists(workingDirResult);
           assertExists(workingDirResult.success);
@@ -267,7 +270,7 @@ describe("Total Function Error Handling Integration", () => {
       results.forEach((result: Result<unknown, UnifiedError>) => {
         assertExists(result);
         assertExists(result.success);
-        assertEquals(result.success, false);
+        assert(!result.success);
       });
 
       // loadConfigSafe should have CONFIG_FILE_NOT_FOUND
@@ -304,9 +307,9 @@ describe("Total Function Error Handling Integration", () => {
 
     it("should support error transformation and recovery", async () => {
       const tempDir = await setupInvalidConfig({
-        working_dir: "",
-        app_prompt: { base_dir: "prompts" },
-        app_schema: { base_dir: "schemas" },
+        "working_dir": "",
+        "app_prompt": { "base_dir": "prompts" },
+        "app_schema": { "base_dir": "schemas" },
       });
 
       try {
@@ -352,8 +355,9 @@ describe("Total Function Error Handling Integration", () => {
       };
 
       // Test success case
+      const SHOULD_NOT_FAIL = false;
       const successResult = await Result.fromPromise(
-        asyncOperation(false),
+        asyncOperation(SHOULD_NOT_FAIL),
         (error) =>
           ErrorFactories.unknown(
             error instanceof Error ? error.message : "Unknown async error",
@@ -366,8 +370,9 @@ describe("Total Function Error Handling Integration", () => {
       assertEquals(successResult.data, "Success");
 
       // Test failure case
+      const SHOULD_FAIL = true;
       const failureResult = await Result.fromPromise(
-        asyncOperation(true),
+        asyncOperation(SHOULD_FAIL),
         (error) =>
           ErrorFactories.unknown(
             error instanceof Error ? error.message : "Unknown async error",

--- a/tests/3.integrated/profile_integration_test.ts
+++ b/tests/3.integrated/profile_integration_test.ts
@@ -16,17 +16,22 @@
  * 5. Integration with configuration loading
  */
 
-import { assertEquals, assertExists, assertRejects as _assertRejects } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertExists,
+  type assertRejects as _assertRejects,
+} from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
 import { BreakdownConfig } from "../../mod.ts";
 import {
   type AppConfig,
-  AppOnlyProfile as _AppOnlyProfile,
-  ConfigProfile as _ConfigProfile,
+  type AppOnlyProfile as _AppOnlyProfile,
+  type ConfigProfile as _ConfigProfile,
   ConfigProfileFactory,
   ConfigProfileGuards,
   ConfigProfileHelpers,
-  MergedProfile as _MergedProfile,
+  type MergedProfile as _MergedProfile,
   type UserConfig as _UserConfig,
 } from "../../src/types/merged_config.ts";
 import { UserConfigFactory } from "../../src/types/user_config.ts";
@@ -58,16 +63,17 @@ describe("Profile Integration Tests", () => {
 
         // When no user config exists, should be app-only
         const mockAppConfig: AppConfig = {
-          working_dir: "./workspace",
-          app_prompt: { base_dir: "./prompts" },
-          app_schema: { base_dir: "./schema" },
+          "working_dir": "./workspace",
+          "app_prompt": { "base_dir": "./prompts" },
+          "app_schema": { "base_dir": "./schema" },
         };
 
+        const HAS_USER_CONFIG = true;
         const profileResult = ConfigProfileFactory.createAppOnly(
           mockAppConfig,
           undefined,
           `${tempDir}/.agent/climpt/config/app.yml`,
-          true,
+          HAS_USER_CONFIG,
         );
 
         assertResultSuccess(profileResult);
@@ -76,9 +82,9 @@ describe("Profile Integration Tests", () => {
 
         // Verify discriminated union
         assertEquals(profile.kind, "app-only");
-        assertEquals(ConfigProfileGuards.isAppOnly(profile), true);
-        assertEquals(ConfigProfileGuards.isMerged(profile), false);
-        assertEquals(profile.source.userConfigExists, false);
+        assert(ConfigProfileGuards.isAppOnly(profile));
+        assert(!ConfigProfileGuards.isMerged(profile));
+        assert(!profile.source.userConfigExists);
       } finally {
         await cleanupTestConfigs(tempDir);
       }
@@ -88,9 +94,9 @@ describe("Profile Integration Tests", () => {
       const tempDir = await setupValidConfig();
       try {
         const mockAppConfig: AppConfig = {
-          working_dir: "./workspace",
-          app_prompt: { base_dir: "./prompts/app" },
-          app_schema: { base_dir: "./schema/app" },
+          "working_dir": "./workspace",
+          "app_prompt": { "base_dir": "./prompts/app" },
+          "app_schema": { "base_dir": "./schema/app" },
         };
 
         const userConfig = UserConfigFactory.createComplete(
@@ -112,9 +118,9 @@ describe("Profile Integration Tests", () => {
 
         // Verify discriminated union
         assertEquals(profile.kind, "merged");
-        assertEquals(ConfigProfileGuards.isMerged(profile), true);
-        assertEquals(ConfigProfileGuards.isAppOnly(profile), false);
-        assertEquals(profile.source.userConfigExists, true);
+        assert(ConfigProfileGuards.isMerged(profile));
+        assert(!ConfigProfileGuards.isAppOnly(profile));
+        assert(profile.source.userConfigExists);
       } finally {
         await cleanupTestConfigs(tempDir);
       }
@@ -124,17 +130,18 @@ describe("Profile Integration Tests", () => {
       const tempDir = await setupValidConfig();
       try {
         const mockAppConfig: AppConfig = {
-          working_dir: "./workspace",
-          app_prompt: { base_dir: "./prompts" },
-          app_schema: { base_dir: "./schema" },
+          "working_dir": "./workspace",
+          "app_prompt": { "base_dir": "./prompts" },
+          "app_schema": { "base_dir": "./schema" },
         };
 
         // Start with app-only
+        const HAS_USER_CONFIG = false;
         const appOnlyResult = ConfigProfileFactory.createAppOnly(
           mockAppConfig,
           "development",
           `${tempDir}/app.yml`,
-          false,
+          HAS_USER_CONFIG,
         );
 
         assertResultSuccess(appOnlyResult);
@@ -168,9 +175,9 @@ describe("Profile Integration Tests", () => {
   describe("Profile Name Validation", () => {
     it("should accept valid profile names", () => {
       const mockAppConfig: AppConfig = {
-        working_dir: "./workspace",
-        app_prompt: { base_dir: "./prompts" },
-        app_schema: { base_dir: "./schema" },
+        "working_dir": "./workspace",
+        "app_prompt": { "base_dir": "./prompts" },
+        "app_schema": { "base_dir": "./schema" },
       };
 
       const validNames = [
@@ -184,11 +191,12 @@ describe("Profile Integration Tests", () => {
       ];
 
       for (const name of validNames) {
+        const HAS_USER_CONFIG = false;
         const result = ConfigProfileFactory.createAppOnly(
           mockAppConfig,
           name,
           "/test/app.yml",
-          false,
+          HAS_USER_CONFIG,
         );
 
         assertResultSuccess(result);
@@ -199,40 +207,42 @@ describe("Profile Integration Tests", () => {
 
     it("should handle default profile (undefined name)", () => {
       const mockAppConfig: AppConfig = {
-        working_dir: "./workspace",
-        app_prompt: { base_dir: "./prompts" },
-        app_schema: { base_dir: "./schema" },
+        "working_dir": "./workspace",
+        "app_prompt": { "base_dir": "./prompts" },
+        "app_schema": { "base_dir": "./schema" },
       };
 
+      const HAS_USER_CONFIG = false;
       const result = ConfigProfileFactory.createAppOnly(
         mockAppConfig,
         undefined,
         "/test/app.yml",
-        false,
+        HAS_USER_CONFIG,
       );
 
       assertResultSuccess(result);
       if (!result.success) throw new Error("Profile creation should have succeeded");
       assertEquals(result.data.profileName, undefined);
-      assertEquals(ConfigProfileGuards.isDefaultProfile(result.data), true);
+      assert(ConfigProfileGuards.isDefaultProfile(result.data));
       assertEquals(ConfigProfileHelpers.getProfileDisplayName(result.data), "default");
     });
 
     it("should maintain profile name consistency", () => {
       const mockAppConfig: AppConfig = {
-        working_dir: "./workspace",
-        app_prompt: { base_dir: "./prompts" },
-        app_schema: { base_dir: "./schema" },
+        "working_dir": "./workspace",
+        "app_prompt": { "base_dir": "./prompts" },
+        "app_schema": { "base_dir": "./schema" },
       };
 
       const profileName = "test_profile";
 
       // Create app-only profile
+      const HAS_USER_CONFIG = false;
       const appOnlyResult = ConfigProfileFactory.createAppOnly(
         mockAppConfig,
         profileName,
         "/test/app.yml",
-        false,
+        HAS_USER_CONFIG,
       );
 
       // Create merged profile with same name
@@ -255,24 +265,25 @@ describe("Profile Integration Tests", () => {
 
       assertEquals(appOnlyResult.data.profileName, profileName);
       assertEquals(mergedResult.data.profileName, profileName);
-      assertEquals(ConfigProfileGuards.isNamedProfile(appOnlyResult.data), true);
-      assertEquals(ConfigProfileGuards.isNamedProfile(mergedResult.data), true);
+      assert(ConfigProfileGuards.isNamedProfile(appOnlyResult.data));
+      assert(ConfigProfileGuards.isNamedProfile(mergedResult.data));
     });
   });
 
   describe("App-Only and Merged State Verification", () => {
     it("should correctly handle app-only state", () => {
       const mockAppConfig: AppConfig = {
-        working_dir: "./workspace",
-        app_prompt: { base_dir: "./prompts/app" },
-        app_schema: { base_dir: "./schema/app" },
+        "working_dir": "./workspace",
+        "app_prompt": { "base_dir": "./prompts/app" },
+        "app_schema": { "base_dir": "./schema/app" },
       };
 
+      const HAS_USER_CONFIG = true;
       const result = ConfigProfileFactory.createAppOnly(
         mockAppConfig,
         "app_only_test",
         "/config/app.yml",
-        true,
+        HAS_USER_CONFIG,
       );
 
       assertResultSuccess(result);
@@ -281,8 +292,8 @@ describe("Profile Integration Tests", () => {
 
       // Verify app-only specific properties
       assertEquals(profile.kind, "app-only");
-      assertEquals(profile.source.userConfigAttempted, true);
-      assertEquals(profile.source.userConfigExists, false);
+      assert(profile.source.userConfigAttempted);
+      assert(!profile.source.userConfigExists);
       assertEquals(profile.config.working_dir, "./workspace");
       assertEquals(profile.config.app_prompt.base_dir, "./prompts/app");
       assertEquals(profile.config.app_schema.base_dir, "./schema/app");
@@ -291,14 +302,14 @@ describe("Profile Integration Tests", () => {
       assertEquals(ConfigProfileHelpers.getWorkingDir(profile), "./workspace");
       assertEquals(ConfigProfileHelpers.getPromptBaseDir(profile), "./prompts/app");
       assertEquals(ConfigProfileHelpers.getSchemaBaseDir(profile), "./schema/app");
-      assertEquals(ConfigProfileHelpers.hasUserCustomization(profile), false);
+      assert(!ConfigProfileHelpers.hasUserCustomization(profile));
     });
 
     it("should correctly handle merged state with user overrides", () => {
       const mockAppConfig: AppConfig = {
-        working_dir: "./workspace",
-        app_prompt: { base_dir: "./prompts/app" },
-        app_schema: { base_dir: "./schema/app" },
+        "working_dir": "./workspace",
+        "app_prompt": { "base_dir": "./prompts/app" },
+        "app_schema": { "base_dir": "./schema/app" },
       };
 
       // User config with overrides
@@ -321,7 +332,7 @@ describe("Profile Integration Tests", () => {
 
       // Verify merged specific properties
       assertEquals(profile.kind, "merged");
-      assertEquals(profile.source.userConfigExists, true);
+      assert(profile.source.userConfigExists);
       assertEquals(profile.source.userConfigPath, "/config/user.yml");
 
       // Working dir should not be overridden
@@ -334,15 +345,15 @@ describe("Profile Integration Tests", () => {
       // Helper functions should reflect overrides
       assertEquals(ConfigProfileHelpers.getPromptBaseDir(profile), "./prompts/user");
       assertEquals(ConfigProfileHelpers.getSchemaBaseDir(profile), "./schema/user");
-      assertEquals(ConfigProfileHelpers.hasUserCustomization(profile), true);
+      assert(ConfigProfileHelpers.hasUserCustomization(profile));
       assertEquals(ConfigProfileHelpers.getUserConfigPath(profile), "/config/user.yml");
     });
 
     it("should handle partial user configs in merged state", () => {
       const mockAppConfig: AppConfig = {
-        working_dir: "./workspace",
-        app_prompt: { base_dir: "./prompts/app" },
-        app_schema: { base_dir: "./schema/app" },
+        "working_dir": "./workspace",
+        "app_prompt": { "base_dir": "./prompts/app" },
+        "app_schema": { "base_dir": "./schema/app" },
       };
 
       // Test with prompt-only user config
@@ -453,16 +464,17 @@ describe("Profile Integration Tests", () => {
 
     it("should validate configuration constraints", () => {
       const invalidAppConfig: AppConfig = {
-        working_dir: "", // Invalid empty string
-        app_prompt: { base_dir: "./prompts" },
-        app_schema: { base_dir: "./schema" },
+        "working_dir": "", // Invalid empty string
+        "app_prompt": { "base_dir": "./prompts" },
+        "app_schema": { "base_dir": "./schema" },
       };
 
+      const HAS_USER_CONFIG = false;
       const result = ConfigProfileFactory.createAppOnly(
         invalidAppConfig,
         "invalid_test",
         "/config/app.yml",
-        false,
+        HAS_USER_CONFIG,
       );
 
       assertResultError(result);
@@ -473,15 +485,16 @@ describe("Profile Integration Tests", () => {
   describe("Error Handling and Edge Cases", () => {
     it("should handle missing required fields", () => {
       const incompleteAppConfig = {
-        working_dir: "./workspace",
+        "working_dir": "./workspace",
         // Missing app_prompt and app_schema
       } as AppConfig;
 
+      const HAS_USER_CONFIG = false;
       const result = ConfigProfileFactory.createAppOnly(
         incompleteAppConfig,
         "incomplete",
         "/config/app.yml",
-        false,
+        HAS_USER_CONFIG,
       );
 
       assertResultError(result);
@@ -490,9 +503,9 @@ describe("Profile Integration Tests", () => {
 
     it("should handle empty user config gracefully", () => {
       const mockAppConfig: AppConfig = {
-        working_dir: "./workspace",
-        app_prompt: { base_dir: "./prompts/app" },
-        app_schema: { base_dir: "./schema/app" },
+        "working_dir": "./workspace",
+        "app_prompt": { "base_dir": "./prompts/app" },
+        "app_schema": { "base_dir": "./schema/app" },
       };
 
       const emptyUser = UserConfigFactory.createEmpty();
@@ -515,16 +528,17 @@ describe("Profile Integration Tests", () => {
 
     it("should maintain immutability of profiles", () => {
       const mockAppConfig: AppConfig = {
-        working_dir: "./workspace",
-        app_prompt: { base_dir: "./prompts" },
-        app_schema: { base_dir: "./schema" },
+        "working_dir": "./workspace",
+        "app_prompt": { "base_dir": "./prompts" },
+        "app_schema": { "base_dir": "./schema" },
       };
 
+      const HAS_USER_CONFIG = false;
       const result = ConfigProfileFactory.createAppOnly(
         mockAppConfig,
         "immutable_test",
         "/config/app.yml",
-        false,
+        HAS_USER_CONFIG,
       );
 
       assertResultSuccess(result);

--- a/tests/3.integrated/unified_error_exports_type_safety_test.ts
+++ b/tests/3.integrated/unified_error_exports_type_safety_test.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+  assert,
   assertEquals,
   assertExists,
   assertInstanceOf,
@@ -36,7 +37,7 @@ describe("Unified Error Final Exports Type Safety Tests", () => {
           throw testCase.input;
         }, `Testing ${testCase.description}`);
 
-        assertEquals(result.success, false);
+        assert(!result.success);
         if (!result.success) {
           assertExists(result.error);
           if (result.error instanceof Error) {
@@ -61,7 +62,7 @@ describe("Unified Error Final Exports Type Safety Tests", () => {
         "Async operation test",
       );
 
-      assertEquals(result.success, false);
+      assert(!result.success);
       if (!result.success) {
         assertExists(result.error);
         if (result.error instanceof Error) {
@@ -88,7 +89,7 @@ describe("Unified Error Final Exports Type Safety Tests", () => {
 
       // Test successful operation
       const result1 = safeDivide(10, 2);
-      assertEquals(result1.success, true);
+      assert(result1.success);
       if (result1.success) {
         assertEquals(result1.data, 5);
         assertEquals(typeof result1.data, "number");
@@ -96,7 +97,7 @@ describe("Unified Error Final Exports Type Safety Tests", () => {
 
       // Test error case
       const result2 = safeDivide(10, 0);
-      assertEquals(result2.success, false);
+      assert(!result2.success);
       if (!result2.success) {
         assertExists(result2.error);
         if (result2.error instanceof Error) {
@@ -121,7 +122,7 @@ describe("Unified Error Final Exports Type Safety Tests", () => {
 
       // Test successful operation
       const result1 = await safeAsyncDivide(20, 4);
-      assertEquals(result1.success, true);
+      assert(result1.success);
       if (result1.success) {
         assertEquals(result1.data, 5);
         assertEquals(typeof result1.data, "number");
@@ -129,7 +130,7 @@ describe("Unified Error Final Exports Type Safety Tests", () => {
 
       // Test error case
       const result2 = await safeAsyncDivide(20, 0);
-      assertEquals(result2.success, false);
+      assert(!result2.success);
       if (!result2.success) {
         assertExists(result2.error);
         if (result2.error instanceof Error) {
@@ -208,8 +209,8 @@ describe("Unified Error Final Exports Type Safety Tests", () => {
       for (const operation of operations) {
         const result = operation();
         assertExists(result);
-        assertEquals(result !== null, true);
-        assertEquals(result !== undefined, true);
+        assert(result !== null);
+        assert(result !== undefined);
         assertExists(result.kind);
         assertExists(result.message);
       }
@@ -230,7 +231,7 @@ describe("Unified Error Final Exports Type Safety Tests", () => {
         }, `Testing ${testCase.description}`);
 
         // Should always return a proper error result
-        assertEquals(result.success, false);
+        assert(!result.success);
         if (!result.success) {
           assertExists(result.error);
           assertExists(result.error.message);
@@ -266,7 +267,7 @@ describe("Unified Error Final Exports Type Safety Tests", () => {
 
       // Test error case
       const result2 = safeGetUser(-1);
-      assertEquals(result2.success, false);
+      assert(!result2.success);
     });
   });
 
@@ -285,7 +286,7 @@ describe("Unified Error Final Exports Type Safety Tests", () => {
           throw error;
         }, "Type guard test");
 
-        assertEquals(result.success, false);
+        assert(!result.success);
         if (!result.success) {
           assertExists(result.error);
           // Should have properly typed error without any casts

--- a/tests/3.integrated/unified_error_type_safety_test.ts
+++ b/tests/3.integrated/unified_error_type_safety_test.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+  assert,
   assertEquals,
   assertExists,
   assertInstanceOf,
@@ -13,14 +14,14 @@ import {
 import { describe, it } from "https://deno.land/std@0.220.1/testing/bdd.ts";
 
 import {
-  BaseErrorInterface,
+  type BaseErrorInterface,
   ErrorCategory,
   ErrorFactories,
   ErrorGuards,
   ErrorHandlingUtils,
   ErrorSeverity,
   QuickErrorFactory,
-  StandardErrorCode as _StandardErrorCode,
+  type StandardErrorCode as _StandardErrorCode,
   unifiedErrorManager,
 } from "../../src/errors/unified_error_final_exports.ts";
 import { ErrorHandlingUtils as ErrorUtilsHandling } from "../../src/errors/error_handling_utils.ts";
@@ -63,7 +64,7 @@ describe("Unified Error Type Safety Integration Tests", () => {
           throw testCase.input;
         }, `Testing ${testCase.description}`);
 
-        assertEquals(result.success, false);
+        assert(!result.success);
         if (!result.success) {
           assertExists(result.error);
           assertEquals(typeof result.error.kind, "string");
@@ -118,7 +119,7 @@ describe("Unified Error Type Safety Integration Tests", () => {
         "Async operation test",
       );
 
-      assertEquals(result.success, false);
+      assert(!result.success);
       if (!result.success) {
         assertExists(result.error);
         assertEquals(result.error.category, ErrorCategory.UNKNOWN);
@@ -136,7 +137,7 @@ describe("Unified Error Type Safety Integration Tests", () => {
         "Sync operation test",
       );
 
-      assertEquals(result.success, false);
+      assert(!result.success);
       if (!result.success) {
         assertExists(result.error);
         assertEquals(result.error.category, ErrorCategory.UNKNOWN);
@@ -156,13 +157,13 @@ describe("Unified Error Type Safety Integration Tests", () => {
       );
 
       const result1 = safeDivide(10, 2);
-      assertEquals(result1.success, true);
+      assert(result1.success);
       if (result1.success) {
         assertEquals(result1.data, 5);
       }
 
       const result2 = safeDivide(10, 0);
-      assertEquals(result2.success, false);
+      assert(!result2.success);
       if (!result2.success) {
         assertExists(result2.error);
         assertEquals(result2.error.category, ErrorCategory.UNKNOWN);
@@ -182,13 +183,13 @@ describe("Unified Error Type Safety Integration Tests", () => {
       );
 
       const result1 = await safeAsyncDivide(20, 4);
-      assertEquals(result1.success, true);
+      assert(result1.success);
       if (result1.success) {
         assertEquals(result1.data, 5);
       }
 
       const result2 = await safeAsyncDivide(20, 0);
-      assertEquals(result2.success, false);
+      assert(!result2.success);
       if (!result2.success) {
         assertExists(result2.error);
         assertEquals(result2.error.category, ErrorCategory.UNKNOWN);
@@ -241,6 +242,7 @@ describe("Unified Error Type Safety Integration Tests", () => {
 
       // Process each error
       for (const error of errors) {
+        // deno-lint-ignore no-await-in-loop
         await unifiedErrorManager.processError(error);
       }
 
@@ -253,7 +255,7 @@ describe("Unified Error Type Safety Integration Tests", () => {
 
       // Verify type safety in report
       assertEquals(typeof report.summary.total, "number");
-      assertEquals(report.summary.total >= errors.length, true);
+      assert(report.summary.total >= errors.length);
     });
 
     it("should maintain type safety in error guards", () => {
@@ -300,8 +302,8 @@ describe("Unified Error Type Safety Integration Tests", () => {
       for (const operation of operations) {
         const result = operation();
         assertExists(result);
-        assertEquals(result !== null, true);
-        assertEquals(result !== undefined, true);
+        assert(result !== null);
+        assert(result !== undefined);
       }
     });
 

--- a/tests/3.integrated/validator_integration_test.ts
+++ b/tests/3.integrated/validator_integration_test.ts
@@ -13,7 +13,7 @@
  * return proper Result types without throwing exceptions
  */
 
-import { assertEquals, assertExists } from "@std/assert";
+import { assert, assertEquals, assertExists } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
 import { ConfigValidator } from "../../src/validators/config_validator.ts";
 import { Result } from "../../src/types/config_result.ts";
@@ -25,18 +25,18 @@ describe("ConfigValidator Integration Tests", () => {
   describe("validateAppConfig - Core Validation", () => {
     it("should successfully validate a complete and valid AppConfig", () => {
       const validConfig: AppConfig = {
-        working_dir: "./.agent/climpt",
-        app_prompt: {
-          base_dir: "./.agent/climpt/prompts/app",
+        "working_dir": "./.agent/climpt",
+        "app_prompt": {
+          "base_dir": "./.agent/climpt/prompts/app",
         },
-        app_schema: {
-          base_dir: "./.agent/climpt/schema/app",
+        "app_schema": {
+          "base_dir": "./.agent/climpt/schema/app",
         },
       };
 
       const result = ConfigValidator.validateAppConfig(validConfig);
 
-      assertEquals(result.success, true);
+      assert(result.success);
       if (result.success) {
         assertEquals(result.data.working_dir, validConfig.working_dir);
         assertEquals(result.data.app_prompt.base_dir, validConfig.app_prompt.base_dir);
@@ -57,15 +57,15 @@ describe("ConfigValidator Integration Tests", () => {
       for (const invalidConfig of invalidConfigs) {
         const result = ConfigValidator.validateAppConfig(invalidConfig);
 
-        assertEquals(result.success, false);
+        assert(!result.success);
         if (!result.success) {
-          assertEquals(result.error.length > 0, true);
+          assert(result.error.length > 0);
           // First error should be either "root" or a required field error
           const hasRootError = result.error.some((e) => e.field === "root");
           const hasRequiredFieldError = result.error.some((e) =>
             ["working_dir", "app_prompt", "app_schema"].includes(e.field)
           );
-          assertEquals(hasRootError || hasRequiredFieldError, true);
+          assert(hasRootError || hasRequiredFieldError);
 
           if (hasRootError) {
             const rootError = result.error.find((e) => e.field === "root");
@@ -79,20 +79,20 @@ describe("ConfigValidator Integration Tests", () => {
     it("should fail validation when required fields are missing", () => {
       const result = ConfigValidator.validateAppConfig({});
 
-      assertEquals(result.success, false);
+      assert(!result.success);
       if (!result.success) {
         assertEquals(result.error.length, 3);
 
         const fieldErrors = result.error.map((e) => e.field);
-        assertEquals(fieldErrors.includes("working_dir"), true);
-        assertEquals(fieldErrors.includes("app_prompt"), true);
-        assertEquals(fieldErrors.includes("app_schema"), true);
+        assert(fieldErrors.includes("working_dir"));
+        assert(fieldErrors.includes("app_prompt"));
+        assert(fieldErrors.includes("app_schema"));
 
         for (const error of result.error) {
           if (error instanceof Error) {
-            assertEquals(error.message?.includes("required"), true);
+            assert(error.message?.includes("required"));
           } else {
-            assertEquals(error.message?.includes("required"), true);
+            assert(error.message?.includes("required"));
           }
         }
       }
@@ -100,14 +100,14 @@ describe("ConfigValidator Integration Tests", () => {
 
     it("should fail validation when fields have incorrect types", () => {
       const invalidConfig = {
-        working_dir: 123,
-        app_prompt: "not an object",
-        app_schema: null,
+        "working_dir": 123,
+        "app_prompt": "not an object",
+        "app_schema": null,
       };
 
       const result = ConfigValidator.validateAppConfig(invalidConfig);
 
-      assertEquals(result.success, false);
+      assert(!result.success);
       if (!result.success) {
         assertEquals(result.error.length, 3);
 
@@ -127,18 +127,18 @@ describe("ConfigValidator Integration Tests", () => {
 
     it("should fail validation when nested fields are invalid", () => {
       const invalidConfig = {
-        working_dir: "./.agent/climpt",
-        app_prompt: {
-          base_dir: 123, // Invalid: should be string
+        "working_dir": "./.agent/climpt",
+        "app_prompt": {
+          "base_dir": 123, // Invalid: should be string
         },
-        app_schema: {
+        "app_schema": {
           // Missing base_dir
         },
       };
 
       const result = ConfigValidator.validateAppConfig(invalidConfig);
 
-      assertEquals(result.success, false);
+      assert(!result.success);
       if (!result.success) {
         assertEquals(result.error.length, 2);
 
@@ -156,18 +156,18 @@ describe("ConfigValidator Integration Tests", () => {
   describe("validateAppConfig - Path Validation", () => {
     it("should fail validation when paths are empty", () => {
       const invalidConfig: AppConfig = {
-        working_dir: "",
-        app_prompt: {
-          base_dir: "   ",
+        "working_dir": "",
+        "app_prompt": {
+          "base_dir": "   ",
         },
-        app_schema: {
-          base_dir: "",
+        "app_schema": {
+          "base_dir": "",
         },
       };
 
       const result = ConfigValidator.validateAppConfig(invalidConfig);
 
-      assertEquals(result.success, false);
+      assert(!result.success);
       if (!result.success) {
         const emptyPathErrors = result.error.filter((e) =>
           e.message?.includes("Path must not be empty")
@@ -181,41 +181,41 @@ describe("ConfigValidator Integration Tests", () => {
 
       for (const char of invalidChars) {
         const invalidConfig: AppConfig = {
-          working_dir: `./.agent/climpt${char}test`,
-          app_prompt: {
-            base_dir: `./.agent/climpt/prompts${char}app`,
+          "working_dir": `./.agent/climpt${char}test`,
+          "app_prompt": {
+            "base_dir": `./.agent/climpt/prompts${char}app`,
           },
-          app_schema: {
-            base_dir: `./.agent/climpt/schema${char}app`,
+          "app_schema": {
+            "base_dir": `./.agent/climpt/schema${char}app`,
           },
         };
 
         const result = ConfigValidator.validateAppConfig(invalidConfig);
 
-        assertEquals(result.success, false);
+        assert(!result.success);
         if (!result.success) {
           const invalidCharErrors = result.error.filter((e) =>
             e.message?.includes("Path contains invalid characters")
           );
-          assertEquals(invalidCharErrors.length >= 1, true);
+          assert(invalidCharErrors.length >= 1);
         }
       }
     });
 
     it("should fail validation when paths contain traversal patterns", () => {
       const invalidConfig: AppConfig = {
-        working_dir: "./.agent/../../../etc/passwd",
-        app_prompt: {
-          base_dir: "./.agent/climpt/../../../prompts",
+        "working_dir": "./.agent/../../../etc/passwd",
+        "app_prompt": {
+          "base_dir": "./.agent/climpt/../../../prompts",
         },
-        app_schema: {
-          base_dir: "./.agent/climpt/schema/../../..",
+        "app_schema": {
+          "base_dir": "./.agent/climpt/schema/../../..",
         },
       };
 
       const result = ConfigValidator.validateAppConfig(invalidConfig);
 
-      assertEquals(result.success, false);
+      assert(!result.success);
       if (!result.success) {
         const traversalErrors = result.error.filter((e) =>
           e.message?.includes("Path traversal detected")
@@ -226,18 +226,18 @@ describe("ConfigValidator Integration Tests", () => {
 
     it("should fail validation when paths are absolute", () => {
       const invalidConfig: AppConfig = {
-        working_dir: "/etc/passwd",
-        app_prompt: {
-          base_dir: "/usr/local/prompts",
+        "working_dir": "/etc/passwd",
+        "app_prompt": {
+          "base_dir": "/usr/local/prompts",
         },
-        app_schema: {
-          base_dir: "/var/lib/schema",
+        "app_schema": {
+          "base_dir": "/var/lib/schema",
         },
       };
 
       const result = ConfigValidator.validateAppConfig(invalidConfig);
 
-      assertEquals(result.success, false);
+      assert(!result.success);
       if (!result.success) {
         const absolutePathErrors = result.error.filter((e) =>
           e.message?.includes("Absolute path not allowed")
@@ -248,22 +248,22 @@ describe("ConfigValidator Integration Tests", () => {
 
     it("should accumulate all path validation errors", () => {
       const invalidConfig: AppConfig = {
-        working_dir: "/absolute/../traversal<invalid>",
-        app_prompt: {
-          base_dir: "",
+        "working_dir": "/absolute/../traversal<invalid>",
+        "app_prompt": {
+          "base_dir": "",
         },
-        app_schema: {
-          base_dir: "relative/path", // This one is valid
+        "app_schema": {
+          "base_dir": "relative/path", // This one is valid
         },
       };
 
       const result = ConfigValidator.validateAppConfig(invalidConfig);
 
-      assertEquals(result.success, false);
+      assert(!result.success);
       if (!result.success) {
         // working_dir should have multiple errors: absolute, traversal, invalid chars
         const workingDirErrors = result.error.filter((e) => e.field === "working_dir");
-        assertEquals(workingDirErrors.length >= 1, true); // At least one error for working_dir
+        assert(workingDirErrors.length >= 1); // At least one error for working_dir
 
         // Check that we have errors for different validation rules
         const _hasAbsoluteError = result.error.some((e) =>
@@ -278,7 +278,7 @@ describe("ConfigValidator Integration Tests", () => {
 
         // app_prompt.base_dir should have 1 error: empty
         const promptErrors = result.error.filter((e) => e.field === "app_prompt.base_dir");
-        assertEquals(promptErrors.length >= 1, true);
+        assert(promptErrors.length >= 1);
 
         // app_schema.base_dir should have no errors
         const schemaErrors = result.error.filter((e) => e.field === "app_schema.base_dir");
@@ -292,9 +292,9 @@ describe("ConfigValidator Integration Tests", () => {
       const emptyConfig = UserConfigFactory.createEmpty();
       const result = ConfigValidator.validateUserConfig(emptyConfig);
 
-      assertEquals(result.success, true);
+      assert(result.success);
       if (result.success) {
-        assertEquals(UserConfigGuards.isEmpty(result.data), true);
+        assert(UserConfigGuards.isEmpty(result.data));
       }
     });
 
@@ -306,12 +306,12 @@ describe("ConfigValidator Integration Tests", () => {
       });
       const result = ConfigValidator.validateUserConfig(emptyConfig);
 
-      assertEquals(result.success, true);
+      assert(result.success);
       if (result.success) {
-        assertEquals(UserConfigGuards.isEmpty(result.data), true);
+        assert(UserConfigGuards.isEmpty(result.data));
         assertEquals(result.data.customFields?.customField1, "value1");
         assertEquals(result.data.customFields?.customField2, 123);
-        assertEquals(result.data.customFields?.customField3, true);
+        assert(result.data.customFields?.customField3);
       }
     });
 
@@ -321,9 +321,9 @@ describe("ConfigValidator Integration Tests", () => {
       );
       const result = ConfigValidator.validateUserConfig(promptConfig);
 
-      assertEquals(result.success, true);
+      assert(result.success);
       if (result.success) {
-        assertEquals(UserConfigGuards.isPromptOnly(result.data), true);
+        assert(UserConfigGuards.isPromptOnly(result.data));
         if (UserConfigGuards.hasPromptConfig(result.data)) {
           assertEquals(result.data.app_prompt.base_dir, "./custom/prompts");
         }
@@ -336,9 +336,9 @@ describe("ConfigValidator Integration Tests", () => {
       );
       const result = ConfigValidator.validateUserConfig(schemaConfig);
 
-      assertEquals(result.success, true);
+      assert(result.success);
       if (result.success) {
-        assertEquals(UserConfigGuards.isSchemaOnly(result.data), true);
+        assert(UserConfigGuards.isSchemaOnly(result.data));
         if (UserConfigGuards.hasSchemaConfig(result.data)) {
           assertEquals(result.data.app_schema.base_dir, "./custom/schemas");
         }
@@ -353,16 +353,16 @@ describe("ConfigValidator Integration Tests", () => {
       );
       const result = ConfigValidator.validateUserConfig(completeConfig);
 
-      assertEquals(result.success, true);
+      assert(result.success);
       if (result.success) {
-        assertEquals(UserConfigGuards.isComplete(result.data), true);
+        assert(UserConfigGuards.isComplete(result.data));
         if (UserConfigGuards.hasPromptConfig(result.data)) {
           assertEquals(result.data.app_prompt.base_dir, "./custom/prompts");
         }
         if (UserConfigGuards.hasSchemaConfig(result.data)) {
           assertEquals(result.data.app_schema.base_dir, "./custom/schemas");
         }
-        assertEquals(result.data.customFields?.debugMode, true);
+        assert(result.data.customFields?.debugMode);
       }
     });
 
@@ -373,9 +373,9 @@ describe("ConfigValidator Integration Tests", () => {
       for (const invalidConfig of invalidConfigs) {
         const result = ConfigValidator.validateUserConfig(invalidConfig);
 
-        assertEquals(result.success, false);
+        assert(!result.success);
         if (!result.success) {
-          assertEquals(result.error.length > 0, true);
+          assert(result.error.length > 0);
           const rootError = result.error.find((e) => e.field === "root");
           assertExists(rootError);
           assertEquals(rootError.expectedType, "object");
@@ -389,7 +389,7 @@ describe("ConfigValidator Integration Tests", () => {
         const result = ConfigValidator.validateUserConfig(config);
         // These pass validation because the validator treats them as
         // empty user configs without prompt or schema overrides
-        assertEquals(result.success, true);
+        assert(result.success);
       }
     });
   });
@@ -397,17 +397,17 @@ describe("ConfigValidator Integration Tests", () => {
   describe("validateUserConfig - Legacy Format Support", () => {
     it("should validate legacy UserConfig with app_prompt only", () => {
       const legacyConfig: LegacyUserConfig = {
-        app_prompt: {
-          base_dir: "./legacy/prompts",
+        "app_prompt": {
+          "base_dir": "./legacy/prompts",
         },
       };
 
       const userConfig = UserConfigFactory.fromLegacy(legacyConfig);
       const result = ConfigValidator.validateUserConfig(userConfig);
 
-      assertEquals(result.success, true);
+      assert(result.success);
       if (result.success) {
-        assertEquals(UserConfigGuards.isPromptOnly(result.data), true);
+        assert(UserConfigGuards.isPromptOnly(result.data));
       }
     });
 
@@ -416,14 +416,14 @@ describe("ConfigValidator Integration Tests", () => {
       // that don't have proper type checking unless they match the discriminated
       // union pattern (have app_prompt or app_schema as objects)
       const invalidLegacyConfig = {
-        app_prompt: "not an object",
+        "app_prompt": "not an object",
       };
 
       const result = ConfigValidator.validateUserConfig(invalidLegacyConfig);
 
       // The current implementation treats this as valid because UserConfigGuards
       // don't recognize it as having prompt config (since app_prompt is not an object)
-      assertEquals(result.success, true);
+      assert(result.success);
     });
 
     it("should validate legacy UserConfig with invalid nested fields", () => {
@@ -431,11 +431,11 @@ describe("ConfigValidator Integration Tests", () => {
       // as valid even if the nested fields have wrong types,
       // because it only validates when the structure matches the expected pattern
       const invalidLegacyConfig = {
-        app_prompt: {
-          base_dir: 123, // Should be string
+        "app_prompt": {
+          "base_dir": 123, // Should be string
         },
-        app_schema: {
-          base_dir: null, // Should be string
+        "app_schema": {
+          "base_dir": null, // Should be string
         },
       };
 
@@ -443,7 +443,7 @@ describe("ConfigValidator Integration Tests", () => {
 
       // Similar to the previous test, this passes because the validator
       // accepts objects that don't strictly conform to the discriminated union types
-      assertEquals(result.success, true);
+      assert(result.success);
     });
   });
 
@@ -457,7 +457,7 @@ describe("ConfigValidator Integration Tests", () => {
 
       const result = ConfigValidator.validateUserConfig(invalidUserConfig);
 
-      assertEquals(result.success, false);
+      assert(!result.success);
       if (!result.success) {
         const absolutePathError = result.error.find((e) =>
           e.field === "app_prompt.base_dir" && e.message?.includes("Absolute path not allowed")
@@ -475,17 +475,17 @@ describe("ConfigValidator Integration Tests", () => {
       // Empty config should pass without path validation
       const emptyConfig = UserConfigFactory.createEmpty();
       const emptyResult = ConfigValidator.validateUserConfig(emptyConfig);
-      assertEquals(emptyResult.success, true);
+      assert(emptyResult.success);
 
       // Prompt-only with valid path should pass
       const promptConfig = UserConfigFactory.createPromptOnly("./valid/path");
       const promptResult = ConfigValidator.validateUserConfig(promptConfig);
-      assertEquals(promptResult.success, true);
+      assert(promptResult.success);
 
       // Schema-only with invalid path should fail
       const schemaConfig = UserConfigFactory.createSchemaOnly("path<with>invalid|chars");
       const schemaResult = ConfigValidator.validateUserConfig(schemaConfig);
-      assertEquals(schemaResult.success, false);
+      assert(!schemaResult.success);
       if (!schemaResult.success) {
         const invalidCharError = schemaResult.error.find((e) =>
           e.message?.includes("Path contains invalid characters")
@@ -498,12 +498,12 @@ describe("ConfigValidator Integration Tests", () => {
   describe("Result Type Integration", () => {
     it("should support Result type chaining with map", () => {
       const validConfig: AppConfig = {
-        working_dir: "./.agent/climpt",
-        app_prompt: {
-          base_dir: "./.agent/climpt/prompts/app",
+        "working_dir": "./.agent/climpt",
+        "app_prompt": {
+          "base_dir": "./.agent/climpt/prompts/app",
         },
-        app_schema: {
-          base_dir: "./.agent/climpt/schema/app",
+        "app_schema": {
+          "base_dir": "./.agent/climpt/schema/app",
         },
       };
 
@@ -512,7 +512,7 @@ describe("ConfigValidator Integration Tests", () => {
         dirs: [config.working_dir, config.app_prompt.base_dir, config.app_schema.base_dir],
       }));
 
-      assertEquals(mappedResult.success, true);
+      assert(mappedResult.success);
       if (mappedResult.success) {
         assertEquals(mappedResult.data.dirs.length, 3);
         assertEquals(mappedResult.data.dirs[0], "./.agent/climpt");
@@ -528,23 +528,23 @@ describe("ConfigValidator Integration Tests", () => {
         fields: errors.map((e) => e.field),
       }));
 
-      assertEquals(mappedResult.success, false);
+      assert(!mappedResult.success);
       if (!mappedResult.success) {
         assertEquals(mappedResult.error.errorCount, 3);
-        assertEquals(mappedResult.error.fields.includes("working_dir"), true);
-        assertEquals(mappedResult.error.fields.includes("app_prompt"), true);
-        assertEquals(mappedResult.error.fields.includes("app_schema"), true);
+        assert(mappedResult.error.fields.includes("working_dir"));
+        assert(mappedResult.error.fields.includes("app_prompt"));
+        assert(mappedResult.error.fields.includes("app_schema"));
       }
     });
 
     it("should support Result type pattern matching", () => {
       const validConfig: AppConfig = {
-        working_dir: "./.agent/climpt",
-        app_prompt: {
-          base_dir: "./.agent/climpt/prompts/app",
+        "working_dir": "./.agent/climpt",
+        "app_prompt": {
+          "base_dir": "./.agent/climpt/prompts/app",
         },
-        app_schema: {
-          base_dir: "./.agent/climpt/schema/app",
+        "app_schema": {
+          "base_dir": "./.agent/climpt/schema/app",
         },
       };
 
@@ -567,9 +567,9 @@ describe("ConfigValidator Integration Tests", () => {
 
     it("should support Result type unwrapOr for default values", () => {
       const defaultConfig: AppConfig = {
-        working_dir: "./default",
-        app_prompt: { base_dir: "./default/prompts" },
-        app_schema: { base_dir: "./default/schemas" },
+        "working_dir": "./default",
+        "app_prompt": { "base_dir": "./default/prompts" },
+        "app_schema": { "base_dir": "./default/schemas" },
       };
 
       const invalidResult = ConfigValidator.validateAppConfig("not an object");
@@ -584,16 +584,16 @@ describe("ConfigValidator Integration Tests", () => {
   describe("Error Accumulation and Reporting", () => {
     it("should accumulate all validation errors in a single result", () => {
       const invalidConfig = {
-        working_dir: "", // Empty path
-        app_prompt: {
-          base_dir: "/absolute/path/../traversal<invalid>", // Multiple violations
+        "working_dir": "", // Empty path
+        "app_prompt": {
+          "base_dir": "/absolute/path/../traversal<invalid>", // Multiple violations
         },
-        app_schema: "not an object", // Type error
+        "app_schema": "not an object", // Type error
       };
 
       const result = ConfigValidator.validateAppConfig(invalidConfig);
 
-      assertEquals(result.success, false);
+      assert(!result.success);
       if (!result.success) {
         // Should have errors for:
         // 1. working_dir empty
@@ -601,7 +601,7 @@ describe("ConfigValidator Integration Tests", () => {
         // 3. app_prompt.base_dir path traversal
         // 4. app_prompt.base_dir invalid characters
         // 5. app_schema type error
-        assertEquals(result.error.length >= 5, true);
+        assert(result.error.length >= 5);
 
         // Check error details
         for (const error of result.error) {
@@ -619,23 +619,23 @@ describe("ConfigValidator Integration Tests", () => {
 
     it("should provide clear error messages for each validation failure", () => {
       const result = ConfigValidator.validateAppConfig({
-        working_dir: 123,
-        app_prompt: null,
-        app_schema: {
+        "working_dir": 123,
+        "app_prompt": null,
+        "app_schema": {
           // Missing base_dir
         },
       });
 
-      assertEquals(result.success, false);
+      assert(!result.success);
       if (!result.success) {
         const workingDirError = result.error.find((e) => e.field === "working_dir");
-        assertEquals(workingDirError?.message?.includes("must be a string"), true);
+        assert(workingDirError?.message?.includes("must be a string"));
 
         const appPromptError = result.error.find((e) => e.field === "app_prompt");
-        assertEquals(appPromptError?.message?.includes("must be an object"), true);
+        assert(appPromptError?.message?.includes("must be an object"));
 
         const schemaBaseDirError = result.error.find((e) => e.field === "app_schema.base_dir");
-        assertEquals(schemaBaseDirError?.message?.includes("required"), true);
+        assert(schemaBaseDirError?.message?.includes("required"));
       }
     });
   });

--- a/tests/test_helpers/result_test_helpers.ts
+++ b/tests/test_helpers/result_test_helpers.ts
@@ -5,14 +5,14 @@
  * ConfigResult patterns and UnifiedError handling.
  */
 
-import { assert, assertEquals, assertExists as _assertExists } from "@std/assert";
-import { ConfigResult, Result as _Result } from "../../src/types/config_result.ts";
+import { assert, assertEquals, type assertExists as _assertExists } from "@std/assert";
+import type { ConfigResult, Result as _Result } from "../../src/types/config_result.ts";
 import {
-  Failure as _Failure,
+  type Failure as _Failure,
   Result as UnifiedResult,
-  Success as _Success,
+  type Success as _Success,
 } from "../../src/types/unified_result.ts";
-import { UnifiedError } from "../../src/errors/unified_errors.ts";
+import type { UnifiedError } from "../../src/errors/unified_errors.ts";
 
 /**
  * Asserts that a Result is successful and returns the data
@@ -253,7 +253,8 @@ export async function assertRejectsWithErrorKind(
 
   try {
     await fn();
-    assert(false, "Expected function to throw but it succeeded");
+    const EXPECTED_THROW = false;
+    assert(EXPECTED_THROW, "Expected function to throw but it succeeded");
   } catch (error) {
     assert(error instanceof Error, "Expected Error instance");
     thrownError = error;
@@ -261,12 +262,10 @@ export async function assertRejectsWithErrorKind(
 
   // Parse the error message to extract UnifiedError information
   // Assuming the error message contains the UnifiedError message
-  if (expectedMessageContent) {
+  if (expectedMessageContent && thrownError) {
     assert(
-      thrownError!.message.includes(expectedMessageContent),
-      `Expected error message to contain '${expectedMessageContent}' but got: ${
-        thrownError!.message
-      }`,
+      thrownError.message.includes(expectedMessageContent),
+      `Expected error message to contain '${expectedMessageContent}' but got: ${thrownError.message}`,
     );
   }
 }

--- a/tests/test_utils.ts
+++ b/tests/test_utils.ts
@@ -24,65 +24,65 @@ export const TEST_WORKING_DIR = ".agent/climpt";
 
 // Valid configuration examples
 export const validAppConfig = {
-  working_dir: DefaultPaths.WORKING_DIR,
-  app_prompt: {
-    base_dir: DefaultPaths.PROMPT_BASE_DIR,
+  "working_dir": DefaultPaths.WORKING_DIR,
+  "app_prompt": {
+    "base_dir": DefaultPaths.PROMPT_BASE_DIR,
   },
-  app_schema: {
-    base_dir: DefaultPaths.SCHEMA_BASE_DIR,
+  "app_schema": {
+    "base_dir": DefaultPaths.SCHEMA_BASE_DIR,
   },
 };
 
 export const validUserConfig = {
-  app_prompt: {
-    base_dir: "custom/prompts",
+  "app_prompt": {
+    "base_dir": "custom/prompts",
   },
 };
 
 // Invalid configuration examples
 export const invalidAppConfigs = {
   missingWorkingDir: {
-    app_prompt: { base_dir: DefaultPaths.PROMPT_BASE_DIR },
-    app_schema: { base_dir: DefaultPaths.SCHEMA_BASE_DIR },
+    "app_prompt": { "base_dir": DefaultPaths.PROMPT_BASE_DIR },
+    "app_schema": { "base_dir": DefaultPaths.SCHEMA_BASE_DIR },
   },
   missingPrompt: {
-    working_dir: DefaultPaths.WORKING_DIR,
-    app_schema: { base_dir: DefaultPaths.SCHEMA_BASE_DIR },
+    "working_dir": DefaultPaths.WORKING_DIR,
+    "app_schema": { "base_dir": DefaultPaths.SCHEMA_BASE_DIR },
   },
   missingSchema: {
-    working_dir: DefaultPaths.WORKING_DIR,
-    app_prompt: { base_dir: DefaultPaths.PROMPT_BASE_DIR },
+    "working_dir": DefaultPaths.WORKING_DIR,
+    "app_prompt": { "base_dir": DefaultPaths.PROMPT_BASE_DIR },
   },
   invalidTypes: {
-    working_dir: 123,
-    app_prompt: { base_dir: true },
-    app_schema: { base_dir: null },
+    "working_dir": 123,
+    "app_prompt": { "base_dir": true },
+    "app_schema": { "base_dir": null },
   },
   emptyStrings: {
-    working_dir: "",
-    app_prompt: { base_dir: DefaultPaths.PROMPT_BASE_DIR },
-    app_schema: { base_dir: DefaultPaths.SCHEMA_BASE_DIR },
+    "working_dir": "",
+    "app_prompt": { "base_dir": DefaultPaths.PROMPT_BASE_DIR },
+    "app_schema": { "base_dir": DefaultPaths.SCHEMA_BASE_DIR },
   },
   emptyWorkingDir: {
-    working_dir: "",
-    app_prompt: { base_dir: DefaultPaths.PROMPT_BASE_DIR },
-    app_schema: { base_dir: DefaultPaths.SCHEMA_BASE_DIR },
+    "working_dir": "",
+    "app_prompt": { "base_dir": DefaultPaths.PROMPT_BASE_DIR },
+    "app_schema": { "base_dir": DefaultPaths.SCHEMA_BASE_DIR },
   },
 };
 
 // Extra field configurations for testing
 export const extraFieldConfigs = {
   rootLevel: {
-    working_dir: DefaultPaths.WORKING_DIR,
-    app_prompt: {
-      base_dir: DefaultPaths.PROMPT_BASE_DIR,
-      extra_field: "extra",
+    "working_dir": DefaultPaths.WORKING_DIR,
+    "app_prompt": {
+      "base_dir": DefaultPaths.PROMPT_BASE_DIR,
+      "extra_field": "extra",
     },
-    app_schema: {
-      base_dir: DefaultPaths.SCHEMA_BASE_DIR,
-      extra_field: "extra",
+    "app_schema": {
+      "base_dir": DefaultPaths.SCHEMA_BASE_DIR,
+      "extra_field": "extra",
     },
-    extra_root_field: "extra",
+    "extra_root_field": "extra",
   },
 };
 
@@ -195,12 +195,12 @@ export async function setupCustomConfigSet(prefix: string): Promise<string> {
   // Create custom app config
   const appConfigPath = join(configDir, `${prefix}-app.yml`);
   const customAppConfig = {
-    working_dir: DefaultPaths.WORKING_DIR,
-    app_prompt: {
-      base_dir: `${prefix}/prompts`,
+    "working_dir": DefaultPaths.WORKING_DIR,
+    "app_prompt": {
+      "base_dir": `${prefix}/prompts`,
     },
-    app_schema: {
-      base_dir: `${prefix}/schemas`,
+    "app_schema": {
+      "base_dir": `${prefix}/schemas`,
     },
   };
   await Deno.writeTextFile(appConfigPath, stringifyYaml(customAppConfig));
@@ -209,8 +209,8 @@ export async function setupCustomConfigSet(prefix: string): Promise<string> {
   // Create custom user config
   const userConfigPath = join(configDir, `${prefix}-user.yml`);
   const customUserConfig = {
-    app_prompt: {
-      base_dir: `${prefix}/user-prompts`,
+    "app_prompt": {
+      "base_dir": `${prefix}/user-prompts`,
     },
   };
   await Deno.writeTextFile(userConfigPath, stringifyYaml(customUserConfig));


### PR DESCRIPTION
## Summary
- Upgrade `@std/*` dependencies to v1.0, `@tettuan/breakdownlogger` to ^1.1.2
- Update lint configuration and CI workflow (setup-deno v2)
- Refactor source and test code for v1.2.3 compatibility
- Update BreakdownLogger documentation (LOG_LENGTH, LOG_KEY, LogEntry)
- Add breakdown-logger Claude Code skill

## Version
- 1.2.3