### PR TITLE
Release 1.2.7: fix JSR meta.json field name in version-check

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Check JSR version availability
         run: |
           DENO_VERSION="${{ steps.get_version.outputs.version }}"
-          JSR_VERSION=$(curl -s https://jsr.io/@tettuan/breakdownconfig/meta.json | jq -r '.latestVersion // "0.0.0"')
+          JSR_VERSION=$(curl -s https://jsr.io/@tettuan/breakdownconfig/meta.json | jq -r '.latest // "0.0.0"')
 
           if [ "$DENO_VERSION" = "$JSR_VERSION" ]; then
             echo "Error: Version $DENO_VERSION already exists on JSR!"

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@tettuan/breakdownconfig",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "A Deno library for managing application and user configurations",
   "author": "tettuan",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Fix `version-check.yml` to read `.latest` (the actual JSR meta.json field) instead of the non-existent `.latestVersion`
- Without this fix, the JSR availability check always compared against `0.0.0` and never detected version collisions
- Version bump: 1.2.6 → 1.2.7

## Test plan
- [ ] CI passes on this PR
- [ ] On develop → main PR, version-check now compares against actual JSR latest version

🤖 Generated with [Claude Code](https://claude.com/claude-code)